### PR TITLE
feat: add support for git diff and status clipboard copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ target/
 # IDE files
 .vscode/
 .idea/
+.git/
+.github/
 *.swp
 *.swo
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,6 +77,20 @@ pub struct Args {
                 inside a <context> block; markdown uses ## headings and fenced code blocks"
     )]
     pub format: crate::formatter::FormatChoice,
+    #[arg(
+        long = "df",
+        num_args = 0..=1,
+        default_missing_value = "0",
+        help = "Copy git diff output to clipboard. Use --df 1 for HEAD~1..HEAD, --df 2 for HEAD~2..HEAD, etc."
+    )]
+    pub df: Option<u8>,
+    #[arg(
+        long = "st",
+        num_args = 0..=1,
+        default_missing_value = "0",
+        help = "Copy git status modified files to clipboard. Use --st N for files changed in last N commits."
+    )]
+    pub st: Option<u8>,
 }
 
 impl Args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -345,6 +345,15 @@ fn main() -> Result<()> {
         }
 
         cw.finish()?;
+        let cwd = std::env::current_dir().ok();
+        for p in &paths {
+            let display = cwd
+                .as_ref()
+                .and_then(|c| std::path::Path::new(p).strip_prefix(c).ok())
+                .map(|rel| rel.display().to_string())
+                .unwrap_or_else(|| p.clone());
+            println!("  {display}");
+        }
         println!(
             "Copied {} tokens from {} files to clipboard.",
             token_counter::format_count(aggregator.token_count()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,10 +101,115 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    if let Some(n) = args.df {
+        let diff_output = if n == 0 {
+            std::process::Command::new("git")
+                .args(["diff"])
+                .output()?
+        } else {
+            let range = format!("HEAD~{n}..HEAD");
+            std::process::Command::new("git")
+                .args(["diff", &range])
+                .output()?
+        };
+        if !diff_output.status.success() {
+            let stderr = String::from_utf8_lossy(&diff_output.stderr);
+            anyhow::bail!("git diff failed: {stderr}");
+        }
+        let diff_text = String::from_utf8_lossy(&diff_output.stdout);
+        if diff_text.is_empty() {
+            println!("No diff output.");
+            return Ok(());
+        }
+        let mut output_handler = OutputHandler::new();
+        let mut cw = output_handler.get_clipboard_writer()?;
+        let counter = token_counter::TokenCounter::new();
+        let tokens = counter.count(&diff_text);
+        if args.print {
+            let stdout = io::stdout();
+            let mut stdout_lock = stdout.lock();
+            {
+                let mut tee = TeeWriter {
+                    a: &mut stdout_lock,
+                    b: &mut cw,
+                };
+                tee.write_all(diff_text.as_bytes())?;
+            }
+        } else {
+            cw.write_all(diff_text.as_bytes())?;
+        }
+        cw.finish()?;
+        let diff_label = if n == 0 {
+            "git diff".to_string()
+        } else {
+            format!("git diff HEAD~{n}..HEAD")
+        };
+        println!(
+            "Copied {} tokens ({}) to clipboard.",
+            token_counter::format_count(tokens),
+            diff_label
+        );
+        return Ok(());
+    }
+    if let Some(n) = args.st {
+        let output = if n == 0 {
+            std::process::Command::new("git")
+                .args(["diff", "--name-only", "HEAD"])
+                .output()?
+        } else {
+            let range = format!("HEAD~{n}..HEAD");
+            std::process::Command::new("git")
+                .args(["diff", "--name-only", &range])
+                .output()?
+        };
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("git diff --name-only failed: {stderr}");
+        }
+        let text = String::from_utf8_lossy(&output.stdout);
+        if text.trim().is_empty() {
+            println!("No changed files.");
+            return Ok(());
+        }
+        let paths: Vec<String> = text.lines().filter(|l| !l.is_empty()).map(String::from).collect();
+        for p in &paths {
+            println!("  {p}");
+        }
+        let fmt = formatter::build_formatter(args.format, args.no_path, args.relative);
+        let mut aggregator = ContentAggregator::new(
+            fmt,
+            args.hidden,
+            args.ignore.clone().into_iter().collect::<Vec<_>>(),
+            !args.no_sort,
+            std::collections::HashSet::new(),
+        );
+        let mut output_handler = OutputHandler::new();
+        let mut cw = output_handler.get_clipboard_writer()?;
+        if args.print {
+            let stdout = io::stdout();
+            let mut stdout_lock = stdout.lock();
+            {
+                let mut tee = TeeWriter {
+                    a: &mut stdout_lock,
+                    b: &mut cw,
+                };
+                aggregator.aggregate_paths(&paths, &mut tee)?;
+            }
+        } else {
+            aggregator.aggregate_paths(&paths, &mut cw)?;
+        }
+        cw.finish()?;
+        eprintln_binary_skip_summary(&aggregator);
+        println!(
+            "Copied {} tokens from {} file{} to clipboard.",
+            token_counter::format_count(aggregator.token_count()),
+            aggregator.file_count(),
+            if aggregator.file_count() == 1 { "" } else { "s" }
+        );
+        return Ok(());
+    }
     let stdin_is_piped = !atty::is(atty::Stream::Stdin);
-
     let mut args = args;
-
     let paths: Vec<String> = if args.tui {
         // --tui explicitly requested: always launch interactive picker, ignore stdin.
         let outcome = tui::run_tui(args.relative, args.no_path)?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,7 +2,7 @@ use fuzzy_matcher::FuzzyMatcher;
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
-    env, io,
+    env, fs, io,
     path::{Path, PathBuf},
     rc::Rc,
 };
@@ -72,6 +72,7 @@ pub struct AppState {
     pub original_scroll_offset: usize,
     pub list_area: Option<ratatui::layout::Rect>,
     selected_file_count_cache: Option<usize>,
+    selected_loc_cache: Option<u64>,
     dir_select_cache: RefCell<HashMap<PathBuf, bool>>,
     dir_files_cache: RefCell<HashMap<PathBuf, Rc<Vec<PathBuf>>>>,
     matcher: fuzzy_matcher::skim::SkimMatcherV2,
@@ -118,6 +119,7 @@ impl AppState {
             original_scroll_offset: 0,
             list_area: None,
             selected_file_count_cache: None,
+            selected_loc_cache: None,
             dir_select_cache: RefCell::new(HashMap::new()),
             dir_files_cache: RefCell::new(HashMap::new()),
             matcher: fuzzy_matcher::skim::SkimMatcherV2::default(),
@@ -149,6 +151,7 @@ impl AppState {
 impl AppState {
     fn invalidate_caches(&mut self) {
         self.selected_file_count_cache = None;
+        self.selected_loc_cache = None;
         self.dir_select_cache.get_mut().clear();
     }
 
@@ -227,6 +230,23 @@ impl AppState {
         let count = self.selected.len();
         self.selected_file_count_cache = Some(count);
         count
+    }
+
+    pub fn selected_loc(&mut self) -> u64 {
+        if let Some(cached) = self.selected_loc_cache {
+            return cached;
+        }
+        let mut loc: u64 = 0;
+        for path in &self.selected {
+            if let Ok(bytes) = fs::read(path) {
+                loc += bytes.iter().filter(|&&b| b == b'\n').count() as u64;
+                if !bytes.is_empty() && *bytes.last().unwrap() != b'\n' {
+                    loc += 1;
+                }
+            }
+        }
+        self.selected_loc_cache = Some(loc);
+        loc
     }
 
     /// Returns the path currently highlighted in the tree cursor.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -87,6 +87,9 @@ pub struct AppState {
     pub git_files_cursor: usize,
     pub git_files_scroll_offset: usize,
     pub git_panel_focused: bool,
+    pub git_marked_commits: HashSet<String>,
+    git_base_selected: HashSet<PathBuf>,
+    git_diff_cache: HashMap<String, Vec<String>>,
     dir_select_cache: RefCell<HashMap<PathBuf, bool>>,
     dir_files_cache: RefCell<HashMap<PathBuf, Rc<Vec<PathBuf>>>>,
     matcher: fuzzy_matcher::skim::SkimMatcherV2,
@@ -141,6 +144,9 @@ impl AppState {
             git_files_cursor: 0,
             git_files_scroll_offset: 0,
             git_panel_focused: true,
+            git_marked_commits: HashSet::new(),
+            git_base_selected: HashSet::new(),
+            git_diff_cache: HashMap::new(),
             dir_select_cache: RefCell::new(HashMap::new()),
             dir_files_cache: RefCell::new(HashMap::new()),
             matcher: fuzzy_matcher::skim::SkimMatcherV2::default(),
@@ -288,71 +294,96 @@ impl AppState {
                         let mut parts = line.splitn(2, '\0');
                         let graph_hash = parts.next().unwrap_or("");
                         let message = parts.next().unwrap_or("");
-                        
+
                         let long_hash = graph_hash
                             .split_whitespace()
                             .find(|s| s.chars().all(|c| c.is_ascii_hexdigit()) && s.len() >= 6)
                             .unwrap_or("");
-                        
-                        let hash = if long_hash.len() >= 6 { long_hash[..6].to_string() } else { String::new() };
-                        
+
+                        let hash = if long_hash.len() >= 6 {
+                            long_hash[..6].to_string()
+                        } else {
+                            String::new()
+                        };
+
                         let display_graph = if !long_hash.is_empty() {
                             graph_hash.replacen(long_hash, &hash, 1)
                         } else {
                             graph_hash.to_string()
                         };
-                        
+
                         let display = if message.is_empty() {
                             display_graph
                         } else {
                             format!("{} {}", display_graph, message)
                         };
-                        
+
                         GitCommit { display, hash }
                     })
                     .collect();
             } else {
-                self.git_commits = vec![GitCommit { 
-                    display: "Failed to load git log. Not a git repository?".to_string(), 
-                    hash: String::new() 
+                self.git_commits = vec![GitCommit {
+                    display: "Failed to load git log. Not a git repository?".to_string(),
+                    hash: String::new(),
                 }];
             }
         } else {
-            self.git_commits = vec![GitCommit { 
-                display: "Failed to execute git command.".to_string(), 
-                hash: String::new() 
+            self.git_commits = vec![GitCommit {
+                display: "Failed to execute git command.".to_string(),
+                hash: String::new(),
             }];
         }
-        
+
         self.git_commit_cursor = 0;
         self.git_files_cursor = 0;
         self.git_commit_scroll_offset = 0;
         self.git_files_scroll_offset = 0;
         self.git_panel_focused = true;
+        self.git_marked_commits.clear();
+        self.git_base_selected = self.selected.clone();
+        self.git_diff_cache.clear();
         self.fetch_git_files();
         self.mode = AppMode::GitTree;
     }
 
     pub fn fetch_git_files(&mut self) {
-        if let Some(commit) = self.git_commits.get(self.git_commit_cursor) {
-            if !commit.hash.is_empty() {
-                if let Ok(output) = std::process::Command::new("git")
-                    .args(["diff-tree", "--no-commit-id", "--name-only", "-r", "--root", &commit.hash])
-                    .output()
-                {
-                    if output.status.success() {
-                        self.git_files = String::from_utf8_lossy(&output.stdout)
-                            .lines()
-                            .map(String::from)
-                            .collect();
-                        self.git_files_cursor = 0;
-                        return;
-                    }
-                }
-            }
-        }
-        self.git_files.clear();
+        let hash = self
+            .git_commits
+            .get(self.git_commit_cursor)
+            .map(|c| c.hash.clone())
+            .unwrap_or_default();
+        self.git_files = self.git_diff_files(&hash);
         self.git_files_cursor = 0;
+    }
+    /// Diff file list for a commit hash, cached across lookups.
+    fn git_diff_files(&mut self, hash: &str) -> Vec<String> {
+        if hash.is_empty() {
+            return Vec::new();
+        }
+        if let Some(cached) = self.git_diff_cache.get(hash) {
+            return cached.clone();
+        }
+        let files: Vec<_> = std::process::Command::new("git")
+            .args([
+                "diff-tree",
+                "--no-commit-id",
+                "--name-only",
+                "-r",
+                "--root",
+                hash,
+            ])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| {
+                String::from_utf8_lossy(&o.stdout)
+                    .lines()
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+        self.git_diff_cache.insert(hash.to_string(), files.clone());
+        files
     }
 
     fn git_file_abs_path(&self, file: &str) -> PathBuf {
@@ -363,35 +394,50 @@ impl AppState {
     pub fn is_git_file_selected(&self, file: &str) -> bool {
         self.selected.contains(&self.git_file_abs_path(file))
     }
+    pub fn is_git_commit_marked(&self, hash: &str) -> bool {
+        !hash.is_empty() && self.git_marked_commits.contains(hash)
+    }
+    /// Toggle a single file's selection from the Files panel. Persists into
+    /// `git_base_selected` so it survives later commit-mark recomputes.
     pub fn toggle_git_file_selection(&mut self) {
         if let Some(file) = self.git_files.get(self.git_files_cursor).cloned() {
             let path = self.git_file_abs_path(&file);
             self.invalidate_caches();
-            if !self.selected.remove(&path) {
-                self.selected.insert(path);
+            if self.selected.remove(&path) {
+                self.git_base_selected.remove(&path);
+            } else {
+                self.selected.insert(path.clone());
+                self.git_base_selected.insert(path);
             }
         }
     }
-    pub fn toggle_git_commit_selection(&mut self) {
-        if self.git_files.is_empty() {
+    /// Toggle the mark on the commit under the cursor, then recompute the
+    /// merged selection: base selection ∪ (union of files touched by every
+    /// marked commit). E.g. marking hash1 (file1), hash2 (file1,file2,file3),
+    /// and hash3 (file2) yields {file1, file2, file3} — overlaps just collapse
+    /// via set union.
+    pub fn toggle_git_commit_mark(&mut self) {
+        let Some(commit) = self.git_commits.get(self.git_commit_cursor).cloned() else {
+            return;
+        };
+        if commit.hash.is_empty() {
             return;
         }
-        let paths: Vec<PathBuf> = self
-            .git_files
-            .iter()
-            .map(|f| self.git_file_abs_path(f))
-            .collect();
-        let all_selected = paths.iter().all(|p| self.selected.contains(p));
+        if !self.git_marked_commits.remove(&commit.hash) {
+            self.git_marked_commits.insert(commit.hash.clone());
+        }
+        self.recompute_git_selection();
+    }
+    fn recompute_git_selection(&mut self) {
         self.invalidate_caches();
-        if all_selected {
-            for p in paths {
-                self.selected.remove(&p);
-            }
-        } else {
-            for p in paths {
-                self.selected.insert(p);
+        let mut merged = self.git_base_selected.clone();
+        let hashes: Vec<String> = self.git_marked_commits.iter().cloned().collect();
+        for hash in hashes {
+            for f in self.git_diff_files(&hash) {
+                merged.insert(self.git_file_abs_path(&f));
             }
         }
+        self.selected = merged;
     }
     pub fn sync_git_scroll(&mut self, visible_height: usize) {
         if self.git_panel_focused {
@@ -408,7 +454,9 @@ impl AppState {
             } else if self.git_commit_cursor >= self.git_commit_scroll_offset + visible_height {
                 self.git_commit_scroll_offset = self.git_commit_cursor + 1 - visible_height;
             }
-            self.git_commit_scroll_offset = self.git_commit_scroll_offset.min(len.saturating_sub(visible_height));
+            self.git_commit_scroll_offset = self
+                .git_commit_scroll_offset
+                .min(len.saturating_sub(visible_height));
         } else {
             let len = self.git_files.len();
             if self.git_files_cursor >= len {
@@ -423,7 +471,9 @@ impl AppState {
             } else if self.git_files_cursor >= self.git_files_scroll_offset + visible_height {
                 self.git_files_scroll_offset = self.git_files_cursor + 1 - visible_height;
             }
-            self.git_files_scroll_offset = self.git_files_scroll_offset.min(len.saturating_sub(visible_height));
+            self.git_files_scroll_offset = self
+                .git_files_scroll_offset
+                .min(len.saturating_sub(visible_height));
         }
     }
 }
@@ -447,9 +497,7 @@ impl AppState {
         self.dir_cache.insert(dir.clone(), entries);
         for subdir in subdirs {
             if let std::collections::hash_map::Entry::Vacant(e) = self.dir_cache.entry(subdir) {
-                if let Ok(sub_entries) =
-                    read_dir_sorted(e.key(), self.respect_gitignore)
-                {
+                if let Ok(sub_entries) = read_dir_sorted(e.key(), self.respect_gitignore) {
                     e.insert(sub_entries);
                 }
             }
@@ -521,7 +569,7 @@ impl AppState {
         if self.search_query.is_empty() {
             self.search_results.clear();
             if let Some(entries) = self.dir_cache.get(&self.root_dir) {
-            for entry in entries {
+                for entry in entries {
                     let path = entry.path();
                     let file_name = entry.file_name().to_string_lossy().to_string();
                     let is_dir = entry.is_dir();
@@ -564,8 +612,9 @@ impl AppState {
                 path.to_string_lossy().to_string()
             };
 
-            if let Some((score, indices)) =
-                self.matcher.fuzzy_indices(&display_name, &self.search_query)
+            if let Some((score, indices)) = self
+                .matcher
+                .fuzzy_indices(&display_name, &self.search_query)
             {
                 results.push(SearchResult {
                     path: path.to_path_buf(),
@@ -616,8 +665,7 @@ impl AppState {
             && self.search_scroll_offset > 0
         {
             self.search_scroll_offset = self.search_cursor.saturating_sub(top_margin);
-        } else if self.search_cursor + bottom_margin
-            >= self.search_scroll_offset + visible_height
+        } else if self.search_cursor + bottom_margin >= self.search_scroll_offset + visible_height
             && self.search_scroll_offset + visible_height < len
         {
             self.search_scroll_offset =

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,7 +2,7 @@ use fuzzy_matcher::FuzzyMatcher;
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
-    env, fs, io,
+    env, io,
     path::{Path, PathBuf},
     rc::Rc,
 };
@@ -23,14 +23,43 @@ pub struct SearchResult {
     pub match_indices: Vec<usize>,
 }
 
+/// Detect whether `dir` is inside a git work-tree.
+fn is_git_repo(dir: &Path) -> bool {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(dir)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[derive(Clone)]
+pub struct DirItem {
+    path: PathBuf,
+    file_name: std::ffi::OsString,
+    is_dir: bool,
+}
+impl DirItem {
+    pub fn path(&self) -> PathBuf {
+        self.path.clone()
+    }
+    pub fn file_name(&self) -> &std::ffi::OsStr {
+        &self.file_name
+    }
+    pub fn is_dir(&self) -> bool {
+        self.is_dir
+    }
+}
+
 pub struct AppState {
     pub root_dir: PathBuf,
     pub tree_state: tui_tree_widget::TreeState<PathBuf>,
-    pub dir_cache: HashMap<PathBuf, Vec<fs::DirEntry>>,
+    pub dir_cache: HashMap<PathBuf, Vec<DirItem>>,
     pub root_history: Vec<PathBuf>,
     pub selected: HashSet<PathBuf>,
     pub relative: bool,
     pub no_path: bool,
+    pub respect_gitignore: bool,
     pub show_help: bool,
     pub search_history: HashMap<PathBuf, (String, Vec<SearchResult>)>,
     pub mode: AppMode,
@@ -51,18 +80,19 @@ pub struct AppState {
 impl AppState {
     pub fn new(relative: bool, no_path: bool) -> io::Result<Self> {
         let root_dir = env::current_dir()?;
+        let respect_gitignore = is_git_repo(&root_dir);
         let mut dir_cache = HashMap::new();
-        let root_entries = read_dir_sorted(&root_dir)?;
+        let root_entries = read_dir_sorted(&root_dir, respect_gitignore)?;
 
         // Eagerly load one level of subdirs so ▶ indicators appear immediately.
         let subdirs: Vec<PathBuf> = root_entries
             .iter()
-            .filter(|e| e.metadata().map(|m| m.is_dir()).unwrap_or(false))
+            .filter(|e| e.is_dir())
             .map(|e| e.path())
             .collect();
         dir_cache.insert(root_dir.clone(), root_entries);
         for subdir in subdirs {
-            if let Ok(sub_entries) = read_dir_sorted(&subdir) {
+            if let Ok(sub_entries) = read_dir_sorted(&subdir, respect_gitignore) {
                 dir_cache.insert(subdir, sub_entries);
             }
         }
@@ -75,6 +105,7 @@ impl AppState {
             selected: HashSet::new(),
             relative,
             no_path,
+            respect_gitignore,
             show_help: false,
             search_history: HashMap::new(),
             mode: AppMode::Normal,
@@ -124,7 +155,7 @@ impl AppState {
     pub fn toggle_selection(&mut self, path: PathBuf, is_dir: bool) {
         self.invalidate_caches();
         if is_dir {
-            let files = files_under(&path);
+            let files = files_under(&path, self.respect_gitignore);
             let all = !files.is_empty() && files.iter().all(|f| self.selected.contains(f));
             if all {
                 for f in files {
@@ -144,7 +175,7 @@ impl AppState {
         if let Some(v) = self.dir_files_cache.borrow().get(dir) {
             return Rc::clone(v);
         }
-        let files = Rc::new(files_under(dir));
+        let files = Rc::new(files_under(dir, self.respect_gitignore));
         self.dir_files_cache
             .borrow_mut()
             .insert(dir.to_path_buf(), Rc::clone(&files));
@@ -212,18 +243,20 @@ impl AppState {
         if self.dir_cache.contains_key(dir) {
             return;
         }
-        let Ok(entries) = read_dir_sorted(dir) else {
+        let Ok(entries) = read_dir_sorted(dir, self.respect_gitignore) else {
             return;
         };
         let subdirs: Vec<PathBuf> = entries
             .iter()
-            .filter(|e| e.metadata().map(|m| m.is_dir()).unwrap_or(false))
+            .filter(|e| e.is_dir())
             .map(|e| e.path())
             .collect();
         self.dir_cache.insert(dir.clone(), entries);
         for subdir in subdirs {
             if let std::collections::hash_map::Entry::Vacant(e) = self.dir_cache.entry(subdir) {
-                if let Ok(sub_entries) = read_dir_sorted(e.key()) {
+                if let Ok(sub_entries) =
+                    read_dir_sorted(e.key(), self.respect_gitignore)
+                {
                     e.insert(sub_entries);
                 }
             }
@@ -295,10 +328,10 @@ impl AppState {
         if self.search_query.is_empty() {
             self.search_results.clear();
             if let Some(entries) = self.dir_cache.get(&self.root_dir) {
-                for entry in entries {
+            for entry in entries {
                     let path = entry.path();
                     let file_name = entry.file_name().to_string_lossy().to_string();
-                    let is_dir = entry.metadata().map(|m| m.is_dir()).unwrap_or(false);
+                    let is_dir = entry.is_dir();
                     self.search_results.push(SearchResult {
                         path,
                         display_name: file_name,
@@ -317,7 +350,7 @@ impl AppState {
 
         let walker = ignore::WalkBuilder::new(&self.root_dir)
             .hidden(false)
-            .git_ignore(false)
+            .git_ignore(self.respect_gitignore)
             .follow_links(false)
             .build();
 
@@ -404,10 +437,10 @@ impl AppState {
 }
 
 /// Returns all files under `dir` using the same walker settings as path collection.
-pub fn files_under(dir: &Path) -> Vec<PathBuf> {
+pub fn files_under(dir: &Path, respect_gitignore: bool) -> Vec<PathBuf> {
     ignore::WalkBuilder::new(dir)
         .hidden(false)
-        .git_ignore(false)
+        .git_ignore(respect_gitignore)
         .follow_links(true)
         .build()
         .filter_map(|e| e.ok())
@@ -416,11 +449,24 @@ pub fn files_under(dir: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
-pub fn read_dir_sorted(dir: &PathBuf) -> io::Result<Vec<fs::DirEntry>> {
-    let mut entries: Vec<_> = fs::read_dir(dir)?.filter_map(|e| e.ok()).collect();
-    entries.sort_by_key(|e| {
-        let md = e.metadata();
-        (!md.as_ref().map(|m| m.is_dir()).unwrap_or(false), e.file_name())
-    });
+pub fn read_dir_sorted(dir: &PathBuf, respect_gitignore: bool) -> io::Result<Vec<DirItem>> {
+    let mut entries: Vec<DirItem> = ignore::WalkBuilder::new(dir)
+        .max_depth(Some(1))
+        .hidden(false)
+        .git_ignore(respect_gitignore)
+        .follow_links(true)
+        .build()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.depth() > 0)
+        .map(|e| {
+            let is_dir = e.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+            DirItem {
+                path: e.path().to_path_buf(),
+                file_name: e.file_name().to_os_string(),
+                is_dir,
+            }
+        })
+        .collect();
+    entries.sort_by_key(|e| (!e.is_dir(), e.file_name().to_os_string()));
     Ok(entries)
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -289,16 +289,23 @@ impl AppState {
                         let graph_hash = parts.next().unwrap_or("");
                         let message = parts.next().unwrap_or("");
                         
-                        let hash = graph_hash
+                        let long_hash = graph_hash
                             .split_whitespace()
                             .find(|s| s.chars().all(|c| c.is_ascii_hexdigit()) && s.len() >= 6)
-                            .map(|s| s[..6].to_string())
-                            .unwrap_or_default();
+                            .unwrap_or("");
+                        
+                        let hash = if long_hash.len() >= 6 { long_hash[..6].to_string() } else { String::new() };
+                        
+                        let display_graph = if !long_hash.is_empty() {
+                            graph_hash.replacen(long_hash, &hash, 1)
+                        } else {
+                            graph_hash.to_string()
+                        };
                         
                         let display = if message.is_empty() {
-                            graph_hash.to_string()
+                            display_graph
                         } else {
-                            format!("{} {}", graph_hash, message)
+                            format!("{} {}", display_graph, message)
                         };
                         
                         GitCommit { display, hash }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -12,6 +12,7 @@ pub enum AppMode {
     Normal,
     SearchFocused,
     SearchNavigating,
+    GitTree,
 }
 
 #[derive(Clone)]
@@ -21,6 +22,12 @@ pub struct SearchResult {
     pub is_dir: bool,
     pub match_score: i64,
     pub match_indices: Vec<usize>,
+}
+
+#[derive(Clone)]
+pub struct GitCommit {
+    pub display: String,
+    pub hash: String,
 }
 
 /// Detect whether `dir` is inside a git work-tree.
@@ -73,6 +80,13 @@ pub struct AppState {
     pub list_area: Option<ratatui::layout::Rect>,
     selected_file_count_cache: Option<usize>,
     selected_loc_cache: Option<u64>,
+    pub git_commits: Vec<GitCommit>,
+    pub git_commit_cursor: usize,
+    pub git_commit_scroll_offset: usize,
+    pub git_files: Vec<String>,
+    pub git_files_cursor: usize,
+    pub git_files_scroll_offset: usize,
+    pub git_panel_focused: bool,
     dir_select_cache: RefCell<HashMap<PathBuf, bool>>,
     dir_files_cache: RefCell<HashMap<PathBuf, Rc<Vec<PathBuf>>>>,
     matcher: fuzzy_matcher::skim::SkimMatcherV2,
@@ -120,6 +134,13 @@ impl AppState {
             list_area: None,
             selected_file_count_cache: None,
             selected_loc_cache: None,
+            git_commits: Vec::new(),
+            git_commit_cursor: 0,
+            git_commit_scroll_offset: 0,
+            git_files: Vec::new(),
+            git_files_cursor: 0,
+            git_files_scroll_offset: 0,
+            git_panel_focused: true,
             dir_select_cache: RefCell::new(HashMap::new()),
             dir_files_cache: RefCell::new(HashMap::new()),
             matcher: fuzzy_matcher::skim::SkimMatcherV2::default(),
@@ -252,6 +273,113 @@ impl AppState {
     /// Returns the path currently highlighted in the tree cursor.
     pub fn highlighted_path(&self) -> Option<PathBuf> {
         self.tree_state.selected().last().cloned()
+    }
+
+    pub fn enter_git_tree_mode(&mut self) {
+        if let Ok(output) = std::process::Command::new("git")
+            .args(["log", "--graph", "--pretty=format:%H%x00%s"])
+            .output()
+        {
+            if output.status.success() {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                self.git_commits = stdout
+                    .lines()
+                    .map(|line| {
+                        let mut parts = line.splitn(2, '\0');
+                        let graph_hash = parts.next().unwrap_or("");
+                        let message = parts.next().unwrap_or("");
+                        
+                        let hash = graph_hash
+                            .split_whitespace()
+                            .find(|s| s.chars().all(|c| c.is_ascii_hexdigit()) && s.len() >= 6)
+                            .map(|s| s[..6].to_string())
+                            .unwrap_or_default();
+                        
+                        let display = if message.is_empty() {
+                            graph_hash.to_string()
+                        } else {
+                            format!("{} {}", graph_hash, message)
+                        };
+                        
+                        GitCommit { display, hash }
+                    })
+                    .collect();
+            } else {
+                self.git_commits = vec![GitCommit { 
+                    display: "Failed to load git log. Not a git repository?".to_string(), 
+                    hash: String::new() 
+                }];
+            }
+        } else {
+            self.git_commits = vec![GitCommit { 
+                display: "Failed to execute git command.".to_string(), 
+                hash: String::new() 
+            }];
+        }
+        
+        self.git_commit_cursor = 0;
+        self.git_files_cursor = 0;
+        self.git_commit_scroll_offset = 0;
+        self.git_files_scroll_offset = 0;
+        self.git_panel_focused = true;
+        self.fetch_git_files();
+        self.mode = AppMode::GitTree;
+    }
+
+    pub fn fetch_git_files(&mut self) {
+        if let Some(commit) = self.git_commits.get(self.git_commit_cursor) {
+            if !commit.hash.is_empty() {
+                if let Ok(output) = std::process::Command::new("git")
+                    .args(["diff-tree", "--no-commit-id", "--name-only", "-r", "--root", &commit.hash])
+                    .output()
+                {
+                    if output.status.success() {
+                        self.git_files = String::from_utf8_lossy(&output.stdout)
+                            .lines()
+                            .map(String::from)
+                            .collect();
+                        self.git_files_cursor = 0;
+                        return;
+                    }
+                }
+            }
+        }
+        self.git_files.clear();
+        self.git_files_cursor = 0;
+    }
+
+    pub fn sync_git_scroll(&mut self, visible_height: usize) {
+        if self.git_panel_focused {
+            let len = self.git_commits.len();
+            if self.git_commit_cursor >= len {
+                self.git_commit_cursor = len.saturating_sub(1);
+            }
+            if len <= visible_height {
+                self.git_commit_scroll_offset = 0;
+                return;
+            }
+            if self.git_commit_cursor < self.git_commit_scroll_offset {
+                self.git_commit_scroll_offset = self.git_commit_cursor;
+            } else if self.git_commit_cursor >= self.git_commit_scroll_offset + visible_height {
+                self.git_commit_scroll_offset = self.git_commit_cursor + 1 - visible_height;
+            }
+            self.git_commit_scroll_offset = self.git_commit_scroll_offset.min(len.saturating_sub(visible_height));
+        } else {
+            let len = self.git_files.len();
+            if self.git_files_cursor >= len {
+                self.git_files_cursor = len.saturating_sub(1);
+            }
+            if len <= visible_height {
+                self.git_files_scroll_offset = 0;
+                return;
+            }
+            if self.git_files_cursor < self.git_files_scroll_offset {
+                self.git_files_scroll_offset = self.git_files_cursor;
+            } else if self.git_files_cursor >= self.git_files_scroll_offset + visible_height {
+                self.git_files_scroll_offset = self.git_files_cursor + 1 - visible_height;
+            }
+            self.git_files_scroll_offset = self.git_files_scroll_offset.min(len.saturating_sub(visible_height));
+        }
     }
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -355,6 +355,44 @@ impl AppState {
         self.git_files_cursor = 0;
     }
 
+    fn git_file_abs_path(&self, file: &str) -> PathBuf {
+        env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(file)
+    }
+    pub fn is_git_file_selected(&self, file: &str) -> bool {
+        self.selected.contains(&self.git_file_abs_path(file))
+    }
+    pub fn toggle_git_file_selection(&mut self) {
+        if let Some(file) = self.git_files.get(self.git_files_cursor).cloned() {
+            let path = self.git_file_abs_path(&file);
+            self.invalidate_caches();
+            if !self.selected.remove(&path) {
+                self.selected.insert(path);
+            }
+        }
+    }
+    pub fn toggle_git_commit_selection(&mut self) {
+        if self.git_files.is_empty() {
+            return;
+        }
+        let paths: Vec<PathBuf> = self
+            .git_files
+            .iter()
+            .map(|f| self.git_file_abs_path(f))
+            .collect();
+        let all_selected = paths.iter().all(|p| self.selected.contains(p));
+        self.invalidate_caches();
+        if all_selected {
+            for p in paths {
+                self.selected.remove(&p);
+            }
+        } else {
+            for p in paths {
+                self.selected.insert(p);
+            }
+        }
+    }
     pub fn sync_git_scroll(&mut self, visible_height: usize) {
         if self.git_panel_focused {
             let len = self.git_commits.len();

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -45,7 +45,7 @@ fn handle_git_tree(
         }
         KeyCode::Char(' ') => {
             if app.git_panel_focused {
-                app.toggle_git_commit_selection();
+                app.toggle_git_commit_mark();
             } else {
                 app.toggle_git_file_selection();
             }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -16,7 +16,49 @@ pub fn handle_key_event(
         AppMode::SearchFocused => handle_search_focused(app, key_event),
         AppMode::SearchNavigating => handle_search_navigating(app, key_event, message),
         AppMode::Normal => handle_normal(app, key_event, message),
+        AppMode::GitTree => handle_git_tree(app, key_event, message),
     }
+}
+
+fn handle_git_tree(
+    app: &mut AppState,
+    key_event: KeyEvent,
+    _message: &mut String,
+) -> Option<Vec<String>> {
+    match key_event.code {
+        KeyCode::Tab => {
+            app.git_panel_focused = !app.git_panel_focused;
+        }
+        KeyCode::Esc => {
+            app.mode = AppMode::Normal;
+        }
+        KeyCode::Char('q') => return Some(vec![]),
+        KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            return Some(vec![])
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            if app.git_panel_focused {
+                if app.git_commit_cursor > 0 {
+                    app.git_commit_cursor -= 1;
+                    app.fetch_git_files();
+                }
+            } else if app.git_files_cursor > 0 {
+                app.git_files_cursor -= 1;
+            }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if app.git_panel_focused {
+                if app.git_commit_cursor + 1 < app.git_commits.len() {
+                    app.git_commit_cursor += 1;
+                    app.fetch_git_files();
+                }
+            } else if app.git_files_cursor + 1 < app.git_files.len() {
+                app.git_files_cursor += 1;
+            }
+        }
+        _ => {}
+    }
+    None
 }
 
 fn handle_search_focused(app: &mut AppState, key_event: KeyEvent) -> Option<Vec<String>> {
@@ -124,17 +166,18 @@ pub fn handle_mouse_event(app: &mut AppState, mouse: MouseEvent, _message: &mut 
                         app.toggle_selection(path, is_dir);
                     }
                 }
-            } else if let Some(area) = app.list_area {
-                let inner_top = area.y + 1;
-                if mouse.row >= inner_top {
-                    let idx =
-                        app.search_scroll_offset + (mouse.row - inner_top) as usize;
-                    if idx < app.search_results.len() {
-                        app.search_cursor = idx;
-                        if let Some(r) = app.search_results.get(idx) {
-                            let path = r.path.clone();
-                            let is_dir = r.is_dir;
-                            app.toggle_selection(path, is_dir);
+            } else if app.mode == AppMode::SearchFocused || app.mode == AppMode::SearchNavigating {
+                if let Some(area) = app.list_area {
+                    let inner_top = area.y + 1;
+                    if mouse.row >= inner_top {
+                        let idx = app.search_scroll_offset + (mouse.row - inner_top) as usize;
+                        if idx < app.search_results.len() {
+                            app.search_cursor = idx;
+                            if let Some(r) = app.search_results.get(idx) {
+                                let path = r.path.clone();
+                                let is_dir = r.is_dir;
+                                app.toggle_selection(path, is_dir);
+                            }
                         }
                     }
                 }
@@ -143,6 +186,15 @@ pub fn handle_mouse_event(app: &mut AppState, mouse: MouseEvent, _message: &mut 
         MouseEventKind::ScrollDown => {
             if app.mode == AppMode::Normal {
                 app.tree_state.scroll_down(1);
+            } else if app.mode == AppMode::GitTree {
+                if app.git_panel_focused {
+                    if app.git_commit_cursor + 1 < app.git_commits.len() {
+                        app.git_commit_cursor += 1;
+                        app.fetch_git_files();
+                    }
+                } else if app.git_files_cursor + 1 < app.git_files.len() {
+                    app.git_files_cursor += 1;
+                }
             } else if app.search_cursor + 1 < app.search_results.len() {
                 app.search_cursor += 1;
                 app.sync_search_scroll(app.visible_height);
@@ -151,6 +203,15 @@ pub fn handle_mouse_event(app: &mut AppState, mouse: MouseEvent, _message: &mut 
         MouseEventKind::ScrollUp => {
             if app.mode == AppMode::Normal {
                 app.tree_state.scroll_up(1);
+            } else if app.mode == AppMode::GitTree {
+                if app.git_panel_focused {
+                    if app.git_commit_cursor > 0 {
+                        app.git_commit_cursor -= 1;
+                        app.fetch_git_files();
+                    }
+                } else if app.git_files_cursor > 0 {
+                    app.git_files_cursor -= 1;
+                }
             } else if app.search_cursor > 0 {
                 app.search_cursor -= 1;
                 app.sync_search_scroll(app.visible_height);
@@ -237,6 +298,9 @@ fn handle_normal(
             if app.no_path {
                 app.relative = false;
             }
+        }
+        KeyCode::Tab => {
+            app.enter_git_tree_mode();
         }
         _ => {}
     }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -23,7 +23,7 @@ pub fn handle_key_event(
 fn handle_git_tree(
     app: &mut AppState,
     key_event: KeyEvent,
-    _message: &mut String,
+    message: &mut String,
 ) -> Option<Vec<String>> {
     match key_event.code {
         KeyCode::Tab => {
@@ -35,6 +35,20 @@ fn handle_git_tree(
         KeyCode::Char('q') => return Some(vec![]),
         KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
             return Some(vec![])
+        }
+        KeyCode::Char('c') => {
+            if app.selected.is_empty() {
+                *message = "No files or directories selected!".to_string();
+            } else {
+                return Some(app.collect_selected_paths());
+            }
+        }
+        KeyCode::Char(' ') => {
+            if app.git_panel_focused {
+                app.toggle_git_commit_selection();
+            } else {
+                app.toggle_git_file_selection();
+            }
         }
         KeyCode::Up | KeyCode::Char('k') => {
             if app.git_panel_focused {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -52,9 +52,10 @@ fn tui_main(
             app.sync_search_scroll(app.visible_height);
         }
         let file_count = app.selected_file_count();
+        let loc_count = app.selected_loc();
         let mut rendered_height: u16 = 0;
         terminal.draw(|f| {
-            rendered_height = render::draw(f, &mut app, &message, file_count);
+            rendered_height = render::draw(f, &mut app, &message, file_count, loc_count);
         })?;
         app.visible_height = rendered_height as usize;
         terminal.backend_mut().flush()?;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -49,7 +49,11 @@ fn tui_main(
     loop {
         // Search mode manages its own cursor scrolling; tree widget self-manages.
         if app.mode != AppMode::Normal {
-            app.sync_search_scroll(app.visible_height);
+            if app.mode == AppMode::GitTree {
+                app.sync_git_scroll(app.visible_height);
+            } else {
+                app.sync_search_scroll(app.visible_height);
+            }
         }
         let file_count = app.selected_file_count();
         let loc_count = app.selected_loc();

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -113,7 +113,7 @@ fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: u
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
         .split(area);
-
+    let hash_style = Style::default().fg(theme::HASH).add_modifier(Modifier::BOLD);
     let commit_items: Vec<ListItem> = app
         .git_commits
         .iter()
@@ -121,21 +121,36 @@ fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: u
         .skip(app.git_commit_scroll_offset)
         .take(list_height)
         .map(|(i, commit)| {
-            let style = if i == app.git_commit_cursor {
+            let is_cursor = i == app.git_commit_cursor;
+            let base_style = if is_cursor {
                 Style::default().bg(theme::CURSOR_BG).fg(theme::FG)
             } else {
                 Style::default().fg(theme::FG)
             };
-            ListItem::new(Line::from(vec![Span::styled(
-                commit.display.clone(),
-                style,
-            )]))
+            let mut h_style = hash_style;
+            if is_cursor {
+                h_style = h_style.bg(theme::CURSOR_BG);
+            }
+            let spans: Vec<Span<'static>> = if !commit.hash.is_empty() {
+                if let Some(pos) = commit.display.find(commit.hash.as_str()) {
+                    let before = commit.display[..pos].to_string();
+                    let after = commit.display[pos + commit.hash.len()..].to_string();
+                    vec![
+                        Span::styled(before, base_style),
+                        Span::styled(commit.hash.clone(), h_style),
+                        Span::styled(after, base_style),
+                    ]
+                } else {
+                    vec![Span::styled(commit.display.clone(), base_style)]
+                }
+            } else {
+                vec![Span::styled(commit.display.clone(), base_style)]
+            };
+            ListItem::new(Line::from(spans))
         })
         .collect();
-
     let commit_list = List::new(commit_items).block(panel("Commits", app.git_panel_focused));
     f.render_widget(commit_list, chunks[0]);
-
     let file_items: Vec<ListItem> = app
         .git_files
         .iter()
@@ -143,18 +158,26 @@ fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: u
         .skip(app.git_files_scroll_offset)
         .take(list_height)
         .map(|(i, file)| {
-            let style = if i == app.git_files_cursor {
+            let is_cursor = i == app.git_files_cursor;
+            let style = if is_cursor {
                 Style::default().bg(theme::CURSOR_BG).fg(theme::FG)
             } else {
                 Style::default().fg(theme::FG)
             };
-            ListItem::new(Line::from(vec![Span::styled(
-                file.clone(),
-                style,
-            )]))
+            let is_selected = app.is_git_file_selected(file);
+            let marker = if is_selected { "✓ " } else { "  " };
+            let line = Line::from(vec![
+                Span::styled(
+                    marker,
+                    Style::default()
+                        .fg(theme::SELECTED)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(file.clone(), style),
+            ]);
+            ListItem::new(line)
         })
         .collect();
-
     let file_list = List::new(file_items).block(panel("Files", !app.git_panel_focused));
     f.render_widget(file_list, chunks[1]);
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -122,23 +122,19 @@ fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: u
         .take(list_height)
         .map(|(i, commit)| {
             let is_cursor = i == app.git_commit_cursor;
-            let base_style = if is_cursor {
-                Style::default().bg(theme::CURSOR_BG).fg(theme::FG)
+            let line_style = if is_cursor {
+                Style::default().bg(theme::CURSOR_BG)
             } else {
-                Style::default().fg(theme::FG)
+                Style::default()
             };
+            let fg_style = Style::default().fg(theme::FG);
             let mut h_style = hash_style;
             if is_cursor {
                 h_style = h_style.bg(theme::CURSOR_BG);
             }
-            let marker_style = if is_cursor {
-                Style::default()
-                    .fg(theme::SELECTED)
-                    .bg(theme::CURSOR_BG)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(theme::SELECTED).add_modifier(Modifier::BOLD)
-            };
+            let marker_style = Style::default()
+                .fg(theme::SELECTED)
+                .add_modifier(Modifier::BOLD);
             let marker = if app.is_git_commit_marked(&commit.hash) {
                 "✓ "
             } else {
@@ -149,16 +145,16 @@ fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: u
                 if let Some(pos) = commit.display.find(commit.hash.as_str()) {
                     let before = commit.display[..pos].to_string();
                     let after = commit.display[pos + commit.hash.len()..].to_string();
-                    spans.push(Span::styled(before, base_style));
+                    spans.push(Span::styled(before, fg_style));
                     spans.push(Span::styled(commit.hash.clone(), h_style));
-                    spans.push(Span::styled(after, base_style));
+                    spans.push(Span::styled(after, fg_style));
                 } else {
-                    spans.push(Span::styled(commit.display.clone(), base_style));
+                    spans.push(Span::styled(commit.display.clone(), fg_style));
                 }
             } else {
-                spans.push(Span::styled(commit.display.clone(), base_style));
+                spans.push(Span::styled(commit.display.clone(), fg_style));
             }
-            ListItem::new(Line::from(spans))
+            ListItem::new(Line::from(spans)).style(line_style)
         })
         .collect();
     let commit_list = List::new(commit_items).block(panel("Commits", app.git_panel_focused));
@@ -171,10 +167,10 @@ fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: u
         .take(list_height)
         .map(|(i, file)| {
             let is_cursor = i == app.git_files_cursor;
-            let style = if is_cursor {
-                Style::default().bg(theme::CURSOR_BG).fg(theme::FG)
+            let line_style = if is_cursor {
+                Style::default().bg(theme::CURSOR_BG)
             } else {
-                Style::default().fg(theme::FG)
+                Style::default()
             };
             let is_selected = app.is_git_file_selected(file);
             let marker = if is_selected { "✓ " } else { "  " };
@@ -185,9 +181,9 @@ fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: u
                         .fg(theme::SELECTED)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(file.clone(), style),
+                Span::styled(file.clone(), Style::default().fg(theme::FG)),
             ]);
-            ListItem::new(line)
+            ListItem::new(line).style(line_style)
         })
         .collect();
     let file_list = List::new(file_items).block(panel("Files", !app.git_panel_focused));
@@ -393,6 +389,7 @@ fn build_help_lines() -> Vec<Line<'static>> {
         ("Backspace", "Parent dir"),
         ("Space", "Select/Unselect"),
         ("/ or Ctrl-f", "Search files"),
+        ("Tab", "Toggle git tree"),
         ("?", "Toggle help"),
         ("c", "Confirm"),
         ("q/Ctrl-c", "Quit"),

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -38,7 +38,7 @@ fn panel(title: &str, focused: bool) -> Block<'static> {
 }
 
 /// Render the full TUI frame and return the inner file-list height in rows.
-pub fn draw(f: &mut Frame, app: &mut AppState, message: &str, file_count: usize) -> u16 {
+pub fn draw(f: &mut Frame, app: &mut AppState, message: &str, file_count: usize, loc_count: u64) -> u16 {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(1)
@@ -48,18 +48,14 @@ pub fn draw(f: &mut Frame, app: &mut AppState, message: &str, file_count: usize)
             Constraint::Length(1),
         ])
         .split(f.area());
-
     let inner_list_height = chunks[1].height.saturating_sub(2);
     app.list_area = Some(chunks[1]);
-
     render_path_bar(f, app, chunks[0]);
     render_file_list(f, app, chunks[1], inner_list_height as usize);
-    render_status_bar(f, chunks[2], message, file_count);
-
+    render_status_bar(f, chunks[2], message, file_count, loc_count);
     if app.show_help {
         render_help_overlay(f, f.area());
     }
-
     inner_list_height
 }
 
@@ -214,7 +210,7 @@ fn render_file_list(f: &mut Frame, app: &mut AppState, area: Rect, list_height: 
     f.render_stateful_widget(tree_widget, area, &mut app.tree_state);
 }
 
-fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize) {
+fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize, loc_count: u64) {
     let hint_str = "space select   c copy   ? help   q quit ";
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
@@ -223,11 +219,10 @@ fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize
             Constraint::Length(hint_str.len() as u16),
         ])
         .split(area);
-
     if message.is_empty() {
         let left = Line::from(vec![Span::styled(
             format!(
-                " {file_count} file{} selected",
+                " {file_count} file{} selected | {loc_count} LOC",
                 if file_count == 1 { "" } else { "s" }
             ),
             Style::default().fg(theme::SELECTED),

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -64,7 +64,7 @@ pub fn draw(f: &mut Frame, app: &mut AppState, message: &str, file_count: usize,
 }
 
 fn render_path_bar(f: &mut Frame, app: &AppState, area: Rect) {
-    let (path, title_str, path_style) = if app.mode != AppMode::Normal {
+    let (path, title_str, path_style) = if app.mode != AppMode::Normal && app.mode != AppMode::GitTree {
         let search_display = format!("Search: {}", app.search_query);
         let title = if app.mode == AppMode::SearchFocused {
             "Enter to search, Esc to leave search".to_string()

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -51,7 +51,11 @@ pub fn draw(f: &mut Frame, app: &mut AppState, message: &str, file_count: usize,
     let inner_list_height = chunks[1].height.saturating_sub(2);
     app.list_area = Some(chunks[1]);
     render_path_bar(f, app, chunks[0]);
-    render_file_list(f, app, chunks[1], inner_list_height as usize);
+    if app.mode == AppMode::GitTree {
+        render_git_tree(f, app, chunks[1], inner_list_height as usize);
+    } else {
+        render_file_list(f, app, chunks[1], inner_list_height as usize);
+    }
     render_status_bar(f, chunks[2], message, file_count, loc_count);
     if app.show_help {
         render_help_overlay(f, f.area());
@@ -102,6 +106,57 @@ fn render_path_bar(f: &mut Frame, app: &AppState, area: Rect) {
         .style(path_style)
         .wrap(Wrap { trim: true });
     f.render_widget(path_widget, area);
+}
+
+fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: usize) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+
+    let commit_items: Vec<ListItem> = app
+        .git_commits
+        .iter()
+        .enumerate()
+        .skip(app.git_commit_scroll_offset)
+        .take(list_height)
+        .map(|(i, commit)| {
+            let style = if i == app.git_commit_cursor {
+                Style::default().bg(theme::CURSOR_BG).fg(theme::FG)
+            } else {
+                Style::default().fg(theme::FG)
+            };
+            ListItem::new(Line::from(vec![Span::styled(
+                commit.display.clone(),
+                style,
+            )]))
+        })
+        .collect();
+
+    let commit_list = List::new(commit_items).block(panel("Commits", app.git_panel_focused));
+    f.render_widget(commit_list, chunks[0]);
+
+    let file_items: Vec<ListItem> = app
+        .git_files
+        .iter()
+        .enumerate()
+        .skip(app.git_files_scroll_offset)
+        .take(list_height)
+        .map(|(i, file)| {
+            let style = if i == app.git_files_cursor {
+                Style::default().bg(theme::CURSOR_BG).fg(theme::FG)
+            } else {
+                Style::default().fg(theme::FG)
+            };
+            ListItem::new(Line::from(vec![Span::styled(
+                file.clone(),
+                style,
+            )]))
+        })
+        .collect();
+
+    let file_list = List::new(file_items).block(panel("Files", !app.git_panel_focused));
+    f.render_widget(file_list, chunks[1]);
 }
 
 fn render_file_list(f: &mut Frame, app: &mut AppState, area: Rect, list_height: usize) {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -10,14 +10,14 @@ use ratatui::{
 };
 use std::{
     collections::{HashMap, HashSet},
-    env, fs,
+    env,
     path::PathBuf,
 };
 use pathdiff::diff_paths;
 use tui_tree_widget::{Tree, TreeItem};
 
 use super::theme;
-use crate::tui::app::{AppMode, AppState};
+use crate::tui::app::{AppMode, AppState, DirItem};
 
 fn panel(title: &str, focused: bool) -> Block<'static> {
     Block::default()
@@ -337,7 +337,7 @@ fn build_help_lines() -> Vec<Line<'static>> {
 /// (top-level entries plus all recursively opened subdirectories).
 fn collect_visible_dirs(
     dir: &PathBuf,
-    dir_cache: &HashMap<PathBuf, Vec<fs::DirEntry>>,
+    dir_cache: &HashMap<PathBuf, Vec<DirItem>>,
     open: &HashSet<Vec<PathBuf>>,
 ) -> Vec<PathBuf> {
     let Some(entries) = dir_cache.get(dir) else {
@@ -346,7 +346,7 @@ fn collect_visible_dirs(
     let mut result = Vec::new();
     for entry in entries {
         let path = entry.path();
-        if entry.metadata().map(|m| m.is_dir()).unwrap_or(false) {
+        if entry.is_dir() {
             result.push(path.clone());
             let is_open = open.iter().any(|kp| kp.last() == Some(&path));
             if is_open {
@@ -401,7 +401,7 @@ fn highlight_matches(
 /// Closed directories with cached entries include flat stubs so the ▶ symbol shows.
 fn build_styled_tree_items(
     dir: &PathBuf,
-    dir_cache: &HashMap<PathBuf, Vec<fs::DirEntry>>,
+    dir_cache: &HashMap<PathBuf, Vec<DirItem>>,
     open: &HashSet<Vec<PathBuf>>,
     selected: &HashSet<PathBuf>,
     fully_selected_dirs: &HashSet<PathBuf>,
@@ -415,7 +415,7 @@ fn build_styled_tree_items(
         .iter()
         .filter_map(|entry| {
             let path = entry.path();
-            let is_dir = entry.metadata().map(|m| m.is_dir()).unwrap_or(false);
+            let is_dir = entry.is_dir();
             let raw_name = entry.file_name().to_string_lossy().to_string();
             let display_name = if is_dir {
                 format!("{}/", raw_name)

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -131,21 +131,33 @@ fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: u
             if is_cursor {
                 h_style = h_style.bg(theme::CURSOR_BG);
             }
-            let spans: Vec<Span<'static>> = if !commit.hash.is_empty() {
+            let marker_style = if is_cursor {
+                Style::default()
+                    .fg(theme::SELECTED)
+                    .bg(theme::CURSOR_BG)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme::SELECTED).add_modifier(Modifier::BOLD)
+            };
+            let marker = if app.is_git_commit_marked(&commit.hash) {
+                "✓ "
+            } else {
+                "  "
+            };
+            let mut spans: Vec<Span<'static>> = vec![Span::styled(marker, marker_style)];
+            if !commit.hash.is_empty() {
                 if let Some(pos) = commit.display.find(commit.hash.as_str()) {
                     let before = commit.display[..pos].to_string();
                     let after = commit.display[pos + commit.hash.len()..].to_string();
-                    vec![
-                        Span::styled(before, base_style),
-                        Span::styled(commit.hash.clone(), h_style),
-                        Span::styled(after, base_style),
-                    ]
+                    spans.push(Span::styled(before, base_style));
+                    spans.push(Span::styled(commit.hash.clone(), h_style));
+                    spans.push(Span::styled(after, base_style));
                 } else {
-                    vec![Span::styled(commit.display.clone(), base_style)]
+                    spans.push(Span::styled(commit.display.clone(), base_style));
                 }
             } else {
-                vec![Span::styled(commit.display.clone(), base_style)]
-            };
+                spans.push(Span::styled(commit.display.clone(), base_style));
+            }
             ListItem::new(Line::from(spans))
         })
         .collect();

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -8,3 +8,4 @@ pub const DIR: Color = tailwind::SKY.c300;
 pub const SELECTED: Color = tailwind::EMERALD.c400;
 pub const CURSOR_BG: Color = tailwind::SLATE.c800;
 pub const MATCH: Color = tailwind::AMBER.c400;
+pub const HASH: Color = tailwind::YELLOW.c400;


### PR DESCRIPTION
- Add `--df` flag to copy git diff output
- Add `--st` flag to copy modified files content
- Support custom commit ranges for both flags

$ cxt --st 1
  src/cli.rs
  src/main.rs
Copied 3,829 tokens from 2 files to clipboard.

$ cxt --df 1
Copied 1,389 tokens (git diff HEAD~1..HEAD) to clipboard.
