### PR TITLE
feat(tui): display git references in commit tree

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,6 +71,13 @@ pub struct Args {
 
     #[arg(
         long,
+        help = "Append aider-style SEARCH/REPLACE patch instructions to the output \
+                (overrides --format)"
+    )]
+    pub aider: bool,
+
+    #[arg(
+        long,
         value_enum,
         default_value = "xml",
         help = "Output format: xml (default) wraps files in <file path=\"...\"> tags \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,6 +98,13 @@ pub struct Args {
         help = "Copy git status modified files to clipboard. Use --st N for files changed in last N commits."
     )]
     pub st: Option<u8>,
+
+    #[arg(
+        long = "rg",
+        value_name = "PATTERN",
+        help = "Run ripgrep to find files matching PATTERN, print match counts, and aggregate them"
+    )]
+    pub rg: Option<String>,
 }
 
 impl Args {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,7 +102,9 @@ pub struct Args {
     #[arg(
         long = "rg",
         value_name = "PATTERN",
-        help = "Run ripgrep to find files matching PATTERN, print match counts, and aggregate them"
+        help = "Run ripgrep to find git-tracked files matching PATTERN, print match counts, \
+                and aggregate them. Optionally restrict search to provided paths \
+                (e.g. `cxt --rg PATTERN src/`)"
     )]
     pub rg: Option<String>,
 }

--- a/src/content_aggregator.rs
+++ b/src/content_aggregator.rs
@@ -494,7 +494,7 @@ mod tests {
 
     fn xml_aggregator(no_path: bool) -> ContentAggregator {
         ContentAggregator::new(
-            build_formatter(FormatChoice::Xml, no_path, false),
+            build_formatter(FormatChoice::Xml, no_path, false, false),
             false,
             vec![],
             true,
@@ -608,7 +608,7 @@ mod tests {
         fs::write(&hidden_file, "Hidden content").unwrap();
 
         let mut aggregator = ContentAggregator::new(
-            build_formatter(FormatChoice::Xml, false, false),
+            build_formatter(FormatChoice::Xml, false, false, false),
             true,
             vec![],
             true,

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -7,7 +7,11 @@ pub trait Formatter: Send + Sync {
     fn document_end(&self) -> &'static str {
         ""
     }
-    fn write_file_header(&self, path: &Path, writer: &mut dyn std::io::Write) -> std::io::Result<()>;
+    fn write_file_header(
+        &self,
+        path: &Path,
+        writer: &mut dyn std::io::Write,
+    ) -> std::io::Result<()>;
     fn file_footer(&self) -> &'static str;
 }
 
@@ -92,7 +96,11 @@ impl XmlFormatter {
         } else {
             None
         };
-        Self { no_path, relative, cwd }
+        Self {
+            no_path,
+            relative,
+            cwd,
+        }
     }
 }
 
@@ -105,7 +113,11 @@ impl Formatter for XmlFormatter {
         "</context>\n"
     }
 
-    fn write_file_header(&self, path: &Path, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+    fn write_file_header(
+        &self,
+        path: &Path,
+        writer: &mut dyn std::io::Write,
+    ) -> std::io::Result<()> {
         if self.no_path {
             writer.write_all(b"<file>\n")
         } else {
@@ -132,12 +144,20 @@ impl MarkdownFormatter {
         } else {
             None
         };
-        Self { no_path, relative, cwd }
+        Self {
+            no_path,
+            relative,
+            cwd,
+        }
     }
 }
 
 impl Formatter for MarkdownFormatter {
-    fn write_file_header(&self, path: &Path, writer: &mut dyn std::io::Write) -> std::io::Result<()> {
+    fn write_file_header(
+        &self,
+        path: &Path,
+        writer: &mut dyn std::io::Write,
+    ) -> std::io::Result<()> {
         let lang = language_for_extension(path);
         if self.no_path {
             writeln!(writer, "```{lang}")
@@ -152,7 +172,83 @@ impl Formatter for MarkdownFormatter {
     }
 }
 
-pub fn build_formatter(choice: FormatChoice, no_path: bool, relative: bool) -> Box<dyn Formatter> {
+const AIDER_PATCH_BLOCK: &str = r#"<patch method="aider">
+Please apply changes using this aider style format all changed in single code block
+```
+// src/filename1.rs
+<<<<<<< SEARCH
+[exact original lines (include enough context to be unique, avoid too thin blocks)]
+=======
+[modified lines]
+>>>>>>> REPLACE
+ // src/filename2.rs
+<<<<<<< SEARCH
+[exact original lines (include enough context to be unique, avoid too thin blocks)]
+=======
+[modified lines]
+>>>>>>> REPLACE
+```
+</patch>
+</context>
+"#;
+
+pub struct AiderFormatter {
+    no_path: bool,
+    relative: bool,
+    cwd: Option<std::path::PathBuf>,
+}
+
+impl AiderFormatter {
+    pub fn new(no_path: bool, relative: bool) -> Self {
+        let cwd = if relative {
+            std::env::current_dir().ok()
+        } else {
+            None
+        };
+        Self {
+            no_path,
+            relative,
+            cwd,
+        }
+    }
+}
+
+impl Formatter for AiderFormatter {
+    fn document_start(&self) -> &'static str {
+        "<context>\n"
+    }
+
+    fn document_end(&self) -> &'static str {
+        AIDER_PATCH_BLOCK
+    }
+
+    fn write_file_header(
+        &self,
+        path: &Path,
+        writer: &mut dyn std::io::Write,
+    ) -> std::io::Result<()> {
+        if self.no_path {
+            writer.write_all(b"<file>\n")
+        } else {
+            let resolved = resolve_display(path, self.relative, self.cwd.as_deref());
+            writeln!(writer, "<file path=\"{resolved}\">")
+        }
+    }
+
+    fn file_footer(&self) -> &'static str {
+        "\n</file>\n"
+    }
+}
+
+pub fn build_formatter(
+    choice: FormatChoice,
+    no_path: bool,
+    relative: bool,
+    aider: bool,
+) -> Box<dyn Formatter> {
+    if aider {
+        return Box::new(AiderFormatter::new(no_path, relative));
+    }
     match choice {
         FormatChoice::Xml => Box::new(XmlFormatter::new(no_path, relative)),
         FormatChoice::Markdown => Box::new(MarkdownFormatter::new(no_path, relative)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,25 +229,60 @@ fn main() -> Result<()> {
     let stdin_is_piped = !atty::is(atty::Stream::Stdin);
     let mut args = args;
     let paths: Vec<String> = if let Some(pattern) = &args.rg {
-        let output = std::process::Command::new("rg")
-            .args(["-c", pattern])
-            .output()
-            .map_err(|e| anyhow::anyhow!("Failed to execute rg: {e}"))?;
+        // Pipe `git ls-files -z -- <paths>` into `xargs -0 rg -c` so ripgrep
+        // only searches git-tracked files in the specified paths.
+        // This safely handles spaces in filenames and avoids ARG_MAX limits.
+        let mut git_cmd = std::process::Command::new("git");
+        git_cmd.args(["ls-files", "-z"]);
+        if !args.paths.is_empty() {
+            git_cmd.arg("--");
+            git_cmd.args(&args.paths);
+        }
+
+        let mut git_child = git_cmd
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("Failed to execute git ls-files: {e}"))?;
+
+        let git_stdout = git_child.stdout.take().unwrap();
+
+        let mut xargs_child = std::process::Command::new("xargs")
+            .args(["-0", "rg", "-c", "--", pattern])
+            .stdin(git_stdout)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("Failed to execute xargs/rg: {e}"))?;
+
+        let output = xargs_child
+            .wait_with_output()
+            .map_err(|e| anyhow::anyhow!("Failed to wait for rg: {e}"))?;
+
+        let _ = git_child.wait();
         let text = String::from_utf8_lossy(&output.stdout);
-        let mut paths = Vec::new();
+        use std::collections::BTreeMap;
+        let mut matches = BTreeMap::new();
         for line in text.lines() {
             if let Some((path, count_str)) = line.rsplit_once(':') {
                 let count: usize = count_str.parse().unwrap_or(0);
-                let noun = if count == 1 { "match" } else { "matches" };
-                println!("{path} ({count} {noun})");
-                paths.push(path.to_string());
+                matches.insert(path.to_string(), count);
             }
         }
-        if paths.is_empty() {
+        if matches.is_empty() {
             println!("No matches found.");
             return Ok(());
         }
-        paths
+        for (path, count) in &matches {
+            let noun = if *count == 1 { "match" } else { "matches" };
+            if atty::is(atty::Stream::Stdout) {
+                // ANSI colors: path = cyan, count = green
+                println!("\x1b[36m{path}\x1b[0m (\x1b[32m{count}\x1b[0m {noun})");
+            } else {
+                println!("{path} ({count} {noun})");
+            }
+        }
+        matches.into_keys().collect()
     } else if args.tui {
         // --tui explicitly requested: always launch interactive picker, ignore stdin.
         let outcome = tui::run_tui(args.relative, args.no_path, args.aider)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,36 +239,53 @@ fn main() -> Result<()> {
             git_cmd.args(&args.paths);
         }
 
-        let mut git_child = git_cmd
+        let git_output = git_cmd
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::inherit())
-            .spawn()
+            .output()
             .map_err(|e| anyhow::anyhow!("Failed to execute git ls-files: {e}"))?;
 
-        let git_stdout = git_child.stdout.take().unwrap();
+        if !git_output.status.success() {
+            let stderr = String::from_utf8_lossy(&git_output.stderr);
+            anyhow::bail!("git ls-files failed: {stderr}");
+        }
 
-        let mut xargs_child = std::process::Command::new("xargs")
-            .args(["-0", "rg", "-c", "--", pattern])
-            .stdin(git_stdout)
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::inherit())
-            .spawn()
-            .map_err(|e| anyhow::anyhow!("Failed to execute xargs/rg: {e}"))?;
+        // Parse NUL-separated paths from `git ls-files -z` into a Vec<String>.
+        let files: Vec<String> = String::from_utf8_lossy(&git_output.stdout)
+            .split('\0')
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
 
-        let output = xargs_child
-            .wait_with_output()
-            .map_err(|e| anyhow::anyhow!("Failed to wait for rg: {e}"))?;
+        if files.is_empty() {
+            println!("No matches found.");
+            return Ok(());
+        }
 
-        let _ = git_child.wait();
-        let text = String::from_utf8_lossy(&output.stdout);
         use std::collections::BTreeMap;
         let mut matches = BTreeMap::new();
-        for line in text.lines() {
-            if let Some((path, count_str)) = line.rsplit_once(':') {
-                let count: usize = count_str.parse().unwrap_or(0);
-                matches.insert(path.to_string(), count);
+
+        // Chunk the files to avoid ARG_MAX limits on command line length,
+        // replicating the behavior of `xargs` without the external dependency.
+        for chunk in files.chunks(500) {
+            let mut rg_cmd = std::process::Command::new("rg");
+            rg_cmd.args(["-c", "--", pattern]);
+            rg_cmd.args(chunk);
+
+            let output = rg_cmd
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::null())
+                .output()?;
+
+            let text = String::from_utf8_lossy(&output.stdout);
+            for line in text.lines() {
+                if let Some((path, count_str)) = line.rsplit_once(':') {
+                    let count: usize = count_str.parse().unwrap_or(0);
+                    matches.insert(path.to_string(), count);
+                }
             }
         }
+
         if matches.is_empty() {
             println!("No matches found.");
             return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,7 +228,27 @@ fn main() -> Result<()> {
     }
     let stdin_is_piped = !atty::is(atty::Stream::Stdin);
     let mut args = args;
-    let paths: Vec<String> = if args.tui {
+    let paths: Vec<String> = if let Some(pattern) = &args.rg {
+        let output = std::process::Command::new("rg")
+            .args(["-c", pattern])
+            .output()
+            .map_err(|e| anyhow::anyhow!("Failed to execute rg: {e}"))?;
+        let text = String::from_utf8_lossy(&output.stdout);
+        let mut paths = Vec::new();
+        for line in text.lines() {
+            if let Some((path, count_str)) = line.rsplit_once(':') {
+                let count: usize = count_str.parse().unwrap_or(0);
+                let noun = if count == 1 { "match" } else { "matches" };
+                println!("{path} ({count} {noun})");
+                paths.push(path.to_string());
+            }
+        }
+        if paths.is_empty() {
+            println!("No matches found.");
+            return Ok(());
+        }
+        paths
+    } else if args.tui {
         // --tui explicitly requested: always launch interactive picker, ignore stdin.
         let outcome = tui::run_tui(args.relative, args.no_path, args.aider)?;
         args.relative = outcome.relative;
@@ -369,14 +389,16 @@ fn main() -> Result<()> {
         }
 
         cw.finish()?;
-        let cwd = std::env::current_dir().ok();
-        for p in &paths {
-            let display = cwd
-                .as_ref()
-                .and_then(|c| std::path::Path::new(p).strip_prefix(c).ok())
-                .map(|rel| rel.display().to_string())
-                .unwrap_or_else(|| p.clone());
-            println!("  {display}");
+        if args.rg.is_none() {
+            let cwd = std::env::current_dir().ok();
+            for p in &paths {
+                let display = cwd
+                    .as_ref()
+                    .and_then(|c| std::path::Path::new(p).strip_prefix(c).ok())
+                    .map(|rel| rel.display().to_string())
+                    .unwrap_or_else(|| p.clone());
+                println!("  {display}");
+            }
         }
         println!(
             "Copied {} tokens from {} files to clipboard.",

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,9 +230,10 @@ fn main() -> Result<()> {
     let mut args = args;
     let paths: Vec<String> = if args.tui {
         // --tui explicitly requested: always launch interactive picker, ignore stdin.
-        let outcome = tui::run_tui(args.relative, args.no_path)?;
+        let outcome = tui::run_tui(args.relative, args.no_path, args.aider)?;
         args.relative = outcome.relative;
         args.no_path = outcome.no_path;
+        args.aider = outcome.aider;
         if outcome.paths.is_empty() {
             println!("No files or directories selected. Exiting.");
             return Ok(());
@@ -254,9 +255,10 @@ fn main() -> Result<()> {
         combined
     } else if args.paths.is_empty() {
         // No stdin pipe, no CLI args: fall back to interactive TUI.
-        let outcome = tui::run_tui(args.relative, args.no_path)?;
+        let outcome = tui::run_tui(args.relative, args.no_path, args.aider)?;
         args.relative = outcome.relative;
         args.no_path = outcome.no_path;
+        args.aider = outcome.aider;
         if outcome.paths.is_empty() {
             println!("No files or directories selected. Exiting.");
             return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,7 +193,7 @@ fn main() -> Result<()> {
         for p in &paths {
             println!("  {p}");
         }
-        let fmt = formatter::build_formatter(args.format, args.no_path, args.relative);
+        let fmt = formatter::build_formatter(args.format, args.no_path, args.relative, args.aider);
         let mut aggregator = ContentAggregator::new(
             fmt,
             args.hidden,
@@ -294,7 +294,7 @@ fn main() -> Result<()> {
             std::process::exit(1);
         });
 
-    let fmt = formatter::build_formatter(args.format, args.no_path, args.relative);
+    let fmt = formatter::build_formatter(args.format, args.no_path, args.relative, args.aider);
     let mut aggregator = ContentAggregator::new(
         fmt,
         args.hidden,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -35,6 +35,12 @@ pub struct GitStashItem {
 }
 
 #[derive(Clone)]
+pub struct GitBranchItem {
+    pub name: String,
+    pub is_current: bool,
+}
+
+#[derive(Clone)]
 pub struct SearchResult {
     pub path: PathBuf,
     pub display_name: String,
@@ -129,6 +135,8 @@ pub struct AppState {
     pub git_status_diff_focused: bool,
     pub git_stash_items: Vec<GitStashItem>,
     pub pending_stash_pop: Option<String>,
+    pub git_branch_items: Vec<GitBranchItem>,
+    pub pending_branch_switch: Option<String>,
     matcher: fuzzy_matcher::skim::SkimMatcherV2,
 }
 
@@ -187,6 +195,8 @@ impl AppState {
             git_status_diff_focused: false,
             git_stash_items: Vec::new(),
             pending_stash_pop: None,
+            git_branch_items: Vec::new(),
+            pending_branch_switch: None,
             matcher: fuzzy_matcher::skim::SkimMatcherV2::default(),
         };
         app.select_first_entry();
@@ -448,7 +458,8 @@ impl AppState {
         }
 
         self.fetch_git_stash_list();
-        let total = items.len() + self.git_stash_items.len();
+        self.fetch_git_branch_list();
+        let total = items.len() + self.git_stash_items.len() + self.git_branch_items.len();
         if self.git_status_cursor >= total {
             self.git_status_cursor = total.saturating_sub(1);
         }
@@ -459,6 +470,7 @@ impl AppState {
         self.git_status_diff_focused = false;
         self.git_base_selected = self.selected.clone();
         self.pending_stash_pop = None;
+        self.pending_branch_switch = None;
         self.mode = AppMode::GitStatus;
         self.fetch_git_status_diff();
     }
@@ -486,9 +498,34 @@ impl AppState {
         self.git_stash_items = items;
     }
 
+    /// Refresh the branch list (used on entering Git Status mode).
+    pub fn fetch_git_branch_list(&mut self) {
+        let output = std::process::Command::new("git")
+            .args(["branch", "--format=%(HEAD)%00%(refname:short)"])
+            .output();
+        let mut items = Vec::new();
+        if let Ok(o) = output {
+            if o.status.success() {
+                let stdout = String::from_utf8_lossy(&o.stdout);
+                for line in stdout.lines() {
+                    let mut parts = line.splitn(2, '\0');
+                    let head = parts.next().unwrap_or("").trim();
+                    let name = parts.next().unwrap_or("").to_string();
+                    if !name.is_empty() {
+                        items.push(GitBranchItem {
+                            name,
+                            is_current: head == "*",
+                        });
+                    }
+                }
+            }
+        }
+        self.git_branch_items = items;
+    }
+
     /// Total number of navigable rows in Git Status mode (file items + stashes).
     pub fn git_status_total_len(&self) -> usize {
-        self.git_status_items.len() + self.git_stash_items.len()
+        self.git_status_items.len() + self.git_stash_items.len() + self.git_branch_items.len()
     }
 
     pub fn fetch_git_files(&mut self) {
@@ -542,28 +579,62 @@ impl AppState {
     pub fn fetch_git_status_diff(&mut self) {
         let items_len = self.git_status_items.len();
         if self.git_status_cursor >= items_len {
-            let stash_idx = self.git_status_cursor - items_len;
-            let Some(stash) = self.git_stash_items.get(stash_idx).cloned() else {
-                self.git_status_diff_content = "No changes in working tree.".to_string();
+            let after_items_idx = self.git_status_cursor - items_len;
+            let stash_len = self.git_stash_items.len();
+
+            if after_items_idx < stash_len {
+                let stash = &self.git_stash_items[after_items_idx];
+                let output = std::process::Command::new("git")
+                    .args(["stash", "show", "-p", &stash.stash_ref])
+                    .output();
+                self.git_status_diff_content = match output {
+                    Ok(o) if o.status.success() => {
+                        let text = String::from_utf8_lossy(&o.stdout).to_string();
+                        if text.is_empty() {
+                            "(no textual diff)".to_string()
+                        } else {
+                            text
+                        }
+                    }
+                    Ok(o) => format!("Error: {}", String::from_utf8_lossy(&o.stderr).trim()),
+                    Err(e) => format!("Failed to run git stash show: {e}"),
+                };
                 self.git_status_diff_scroll_offset = 0;
                 self.git_status_diff_cursor = 0;
                 return;
-            };
-            let output = std::process::Command::new("git")
-                .args(["stash", "show", "-p", &stash.stash_ref])
-                .output();
-            self.git_status_diff_content = match output {
-                Ok(o) if o.status.success() => {
-                    let text = String::from_utf8_lossy(&o.stdout).to_string();
-                    if text.is_empty() {
-                        "(no textual diff)".to_string()
-                    } else {
-                        text
-                    }
+            }
+
+            let branch_idx = after_items_idx - stash_len;
+            if branch_idx < self.git_branch_items.len() {
+                let branch = &self.git_branch_items[branch_idx];
+                if branch.is_current {
+                    self.git_status_diff_content = format!(
+                        "Already on branch '{}'.\n\nSelect another branch and press Enter to switch.",
+                        branch.name
+                    );
+                } else {
+                    let output = std::process::Command::new("git")
+                        .args(["log", "--oneline", "-20", &branch.name])
+                        .output();
+                    self.git_status_diff_content = match output {
+                        Ok(o) if o.status.success() => {
+                            let text = String::from_utf8_lossy(&o.stdout).to_string();
+                            if text.is_empty() {
+                                format!("(no commits on branch '{}')", branch.name)
+                            } else {
+                                format!("Recent commits on '{}':\n\n{}", branch.name, text)
+                            }
+                        }
+                        Ok(o) => format!("Error: {}", String::from_utf8_lossy(&o.stderr).trim()),
+                        Err(e) => format!("Failed to run git log: {e}"),
+                    };
                 }
-                Ok(o) => format!("Error: {}", String::from_utf8_lossy(&o.stderr).trim()),
-                Err(e) => format!("Failed to run git stash show: {e}"),
-            };
+                self.git_status_diff_scroll_offset = 0;
+                self.git_status_diff_cursor = 0;
+                return;
+            }
+
+            self.git_status_diff_content = "No changes in working tree.".to_string();
             self.git_status_diff_scroll_offset = 0;
             self.git_status_diff_cursor = 0;
             return;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -156,6 +156,9 @@ pub struct AppState {
     /// files (left panel) instead of between individual match lines (right
     /// panel). Toggled with Tab.
     pub rg_files_focused: bool,
+    /// Cursor for the Files (left) panel. Independent of `rg_cursor` (the
+    /// right/match panel) — moving one never touches the other.
+    pub rg_file_cursor: usize,
 }
 
 impl AppState {
@@ -221,6 +224,7 @@ impl AppState {
             rg_cursor: 0,
             rg_scroll_offset: 0,
             rg_files_focused: false,
+            rg_file_cursor: 0,
         };
         app.select_first_entry();
         Ok(app)
@@ -254,6 +258,7 @@ impl AppState {
         self.rg_cursor = 0;
         self.rg_scroll_offset = 0;
         self.rg_files_focused = false;
+        self.rg_file_cursor = 0;
     }
     pub fn exit_rg(&mut self) {
         self.mode = AppMode::Normal;
@@ -262,6 +267,7 @@ impl AppState {
         self.rg_cursor = 0;
         self.rg_scroll_offset = 0;
         self.rg_files_focused = false;
+        self.rg_file_cursor = 0;
     }
     pub fn push_rg_char(&mut self, c: char) {
         self.rg_query.push(c);
@@ -339,6 +345,7 @@ impl AppState {
         self.rg_results = parsed;
         self.rg_cursor = 0;
         self.rg_scroll_offset = 0;
+        self.rg_file_cursor = 0;
     }
     /// Clamp the cursor to valid bounds. The scroll offset (in grouped/visual
     /// row space, i.e. including file-header rows) is computed directly by
@@ -350,38 +357,32 @@ impl AppState {
             self.rg_cursor = len.saturating_sub(1);
         }
     }
-    /// Move the cursor to the first match of the previous file group
-    /// (used when the left/Files panel has focus).
-    pub fn rg_cursor_prev_file(&mut self) {
-        let Some(current) = self.rg_results.get(self.rg_cursor).map(|r| r.path.clone()) else {
-            return;
-        };
-        let mut start = self.rg_cursor;
-        while start > 0 && self.rg_results[start - 1].path == current {
-            start -= 1;
+    /// Unique file paths among current rg results, in first-seen order.
+    /// Backs the Files (left) panel, which navigates independently of the
+    /// match cursor (`rg_cursor`) used by the right panel.
+    pub fn rg_match_files(&self) -> Vec<PathBuf> {
+        let mut seen = HashSet::new();
+        let mut files = Vec::new();
+        for result in &self.rg_results {
+            if seen.insert(result.path.clone()) {
+                files.push(result.path.clone());
+            }
         }
-        if start == 0 {
-            return;
-        }
-        let prev_path = self.rg_results[start - 1].path.clone();
-        let mut prev_start = start - 1;
-        while prev_start > 0 && self.rg_results[prev_start - 1].path == prev_path {
-            prev_start -= 1;
-        }
-        self.rg_cursor = prev_start;
+        files
     }
-    /// Move the cursor to the first match of the next file group
-    /// (used when the left/Files panel has focus).
-    pub fn rg_cursor_next_file(&mut self) {
-        let Some(current) = self.rg_results.get(self.rg_cursor).map(|r| r.path.clone()) else {
-            return;
-        };
-        let mut idx = self.rg_cursor;
-        while idx < self.rg_results.len() && self.rg_results[idx].path == current {
-            idx += 1;
+    /// Move the Files panel cursor up by one. Never touches `rg_cursor` —
+    /// the right panel stays exactly where it is until focus tabs over.
+    pub fn rg_file_cursor_up(&mut self) {
+        if self.rg_file_cursor > 0 {
+            self.rg_file_cursor -= 1;
         }
-        if idx < self.rg_results.len() {
-            self.rg_cursor = idx;
+    }
+    /// Move the Files panel cursor down by one, bounded by the number of
+    /// distinct matched files. Never touches `rg_cursor`.
+    pub fn rg_file_cursor_down(&mut self) {
+        let len = self.rg_match_files().len();
+        if self.rg_file_cursor + 1 < len {
+            self.rg_file_cursor += 1;
         }
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -77,6 +77,7 @@ impl DirItem {
 }
 
 pub struct AppState {
+    pub aider: bool,
     pub root_dir: PathBuf,
     pub tree_state: tui_tree_widget::TreeState<PathBuf>,
     pub dir_cache: HashMap<PathBuf, Vec<DirItem>>,
@@ -124,7 +125,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(relative: bool, no_path: bool) -> io::Result<Self> {
+    pub fn new(relative: bool, no_path: bool, aider: bool) -> io::Result<Self> {
         let root_dir = env::current_dir()?;
         let respect_gitignore = is_git_repo(&root_dir);
         let mut dir_cache = HashMap::new();
@@ -132,6 +133,7 @@ impl AppState {
         dir_cache.insert(root_dir.clone(), root_entries);
 
         let mut app = Self {
+            aider,
             root_dir,
             tree_state: tui_tree_widget::TreeState::default(),
             dir_cache,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -13,6 +13,8 @@ pub enum AppMode {
     SearchNavigating,
     GitTree,
     GitStatus,
+    RgFocused,
+    RgNavigating,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -46,6 +48,14 @@ pub struct SearchResult {
     pub display_name: String,
     pub is_dir: bool,
     pub match_score: i64,
+    pub match_indices: Vec<usize>,
+}
+
+#[derive(Clone)]
+pub struct RgResult {
+    pub path: PathBuf,
+    pub line_number: usize,
+    pub line_content: String,
     pub match_indices: Vec<usize>,
 }
 
@@ -138,6 +148,10 @@ pub struct AppState {
     pub git_branch_items: Vec<GitBranchItem>,
     pub pending_branch_switch: Option<String>,
     matcher: fuzzy_matcher::skim::SkimMatcherV2,
+    pub rg_query: String,
+    pub rg_results: Vec<RgResult>,
+    pub rg_cursor: usize,
+    pub rg_scroll_offset: usize,
 }
 
 impl AppState {
@@ -198,6 +212,10 @@ impl AppState {
             git_branch_items: Vec::new(),
             pending_branch_switch: None,
             matcher: fuzzy_matcher::skim::SkimMatcherV2::default(),
+            rg_query: String::new(),
+            rg_results: Vec::new(),
+            rg_cursor: 0,
+            rg_scroll_offset: 0,
         };
         app.select_first_entry();
         Ok(app)
@@ -222,7 +240,132 @@ impl AppState {
     }
 }
 
-// SelectionExt
+// RgExt (ripgrep content search mode)
+impl AppState {
+    pub fn enter_rg(&mut self) {
+        self.mode = AppMode::RgFocused;
+        self.rg_query.clear();
+        self.rg_results.clear();
+        self.rg_cursor = 0;
+        self.rg_scroll_offset = 0;
+    }
+
+    pub fn exit_rg(&mut self) {
+        self.mode = AppMode::Normal;
+        self.rg_query.clear();
+        self.rg_results.clear();
+        self.rg_cursor = 0;
+        self.rg_scroll_offset = 0;
+    }
+
+    pub fn push_rg_char(&mut self, c: char) {
+        self.rg_query.push(c);
+        self.update_rg();
+    }
+
+    pub fn pop_rg_char(&mut self) {
+        self.rg_query.pop();
+        self.update_rg();
+    }
+
+    pub fn update_rg(&mut self) {
+        if self.rg_query.is_empty() {
+            self.rg_results.clear();
+            self.rg_cursor = 0;
+            self.rg_scroll_offset = 0;
+            return;
+        }
+
+        let git_child = std::process::Command::new("git")
+            .args(["ls-files", "-z", "--"])
+            .arg(&self.root_dir)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+
+        let output = match git_child {
+            Ok(mut git_child) => {
+                let git_stdout = git_child.stdout.take().unwrap();
+                let result = std::process::Command::new("xargs")
+                    .args([
+                        "-0", "rg", "--line-number", "--no-heading",
+                        "--color=never", "--", &self.rg_query,
+                    ])
+                    .stdin(git_stdout)
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::null())
+                    .output();
+                let _ = git_child.wait();
+                match result {
+                    Ok(o) => String::from_utf8_lossy(&o.stdout).to_string(),
+                    Err(_) => String::new(),
+                }
+            }
+            Err(_) => String::new(),
+        };
+
+        let query_lower = self.rg_query.to_lowercase();
+        let query_char_count = self.rg_query.chars().count();
+        let mut parsed = Vec::new();
+        for line in output.lines() {
+            let parts: Vec<&str> = line.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let path = PathBuf::from(parts[0]);
+                let line_num: usize = parts[1].parse().unwrap_or(0);
+                let content = parts[2];
+
+                let mut indices = Vec::new();
+                let content_lower = content.to_lowercase();
+                let mut start = 0;
+                while let Some(pos) = content_lower[start..].find(&query_lower) {
+                    let abs = start + pos;
+                    for i in 0..query_char_count {
+                        indices.push(abs + i);
+                    }
+                    start = abs + query_char_count;
+                }
+
+                parsed.push(RgResult {
+                    path,
+                    line_number: line_num,
+                    line_content: content.to_string(),
+                    match_indices: indices,
+                });
+            }
+        }
+        self.rg_results = parsed;
+        self.rg_cursor = 0;
+        self.rg_scroll_offset = 0;
+    }
+
+    pub fn sync_rg_scroll(&mut self, visible_height: usize) {
+        let len = self.rg_results.len();
+        if self.rg_cursor >= len {
+            self.rg_cursor = len.saturating_sub(1);
+        }
+        if len <= visible_height {
+            self.rg_scroll_offset = 0;
+            return;
+        }
+        let top_margin = 2;
+        let bottom_margin = 2;
+        if self.rg_cursor < self.rg_scroll_offset + top_margin
+            && self.rg_scroll_offset > 0
+        {
+            self.rg_scroll_offset = self.rg_cursor.saturating_sub(top_margin);
+        } else if self.rg_cursor + bottom_margin >= self.rg_scroll_offset + visible_height
+            && self.rg_scroll_offset + visible_height < len
+        {
+            self.rg_scroll_offset =
+                (self.rg_cursor + bottom_margin + 1).saturating_sub(visible_height);
+        }
+        self.rg_scroll_offset = self
+            .rg_scroll_offset
+            .min(len.saturating_sub(visible_height));
+    }
+}
+
+// ScrollExt (search mode only — tree widget self-manages scrolling)
 impl AppState {
     pub(crate) fn invalidate_caches(&mut self) {
         self.selected_file_count_cache = None;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -284,36 +284,48 @@ impl AppState {
             self.rg_scroll_offset = 0;
             return;
         }
-        let git_child = std::process::Command::new("git")
+        let git_result = std::process::Command::new("git")
             .args(["ls-files", "-z", "--"])
             .arg(&self.root_dir)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
-            .spawn();
-        let output = match git_child {
-            Ok(mut git_child) => {
-                let git_stdout = git_child.stdout.take().unwrap();
-                let result = std::process::Command::new("xargs")
-                    .args([
-                        "-0",
-                        "rg",
-                        "--line-number",
-                        "--no-heading",
-                        "--color=never",
-                        "--",
-                        &self.rg_query,
-                    ])
-                    .stdin(git_stdout)
-                    .stdout(std::process::Stdio::piped())
-                    .stderr(std::process::Stdio::null())
-                    .output();
-                let _ = git_child.wait();
-                match result {
-                    Ok(o) => String::from_utf8_lossy(&o.stdout).to_string(),
-                    Err(_) => String::new(),
+            .output();
+        let output = match git_result {
+            Ok(git_output) if git_output.status.success() => {
+                let files: Vec<String> = String::from_utf8_lossy(&git_output.stdout)
+                    .split('\0')
+                    .filter(|s| !s.is_empty())
+                    .map(String::from)
+                    .collect();
+
+                if files.is_empty() {
+                    String::new()
+                } else {
+                    let mut combined = String::new();
+                    // Chunk files to avoid ARG_MAX limits (replicates `xargs`).
+                    for chunk in files.chunks(500) {
+                        let mut rg_cmd = std::process::Command::new("rg");
+                        rg_cmd.args([
+                            "--line-number",
+                            "--no-heading",
+                            "--color=never",
+                            "--",
+                            &self.rg_query,
+                        ]);
+                        rg_cmd.args(chunk);
+
+                        let rg_result = rg_cmd
+                            .stdout(std::process::Stdio::piped())
+                            .stderr(std::process::Stdio::null())
+                            .output();
+                        if let Ok(o) = rg_result {
+                            combined.push_str(&String::from_utf8_lossy(&o.stdout));
+                        }
+                    }
+                    combined
                 }
             }
-            Err(_) => String::new(),
+            _ => String::new(),
         };
         let query_lower = self.rg_query.to_lowercase();
         let query_char_count = self.rg_query.chars().count();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -152,6 +152,10 @@ pub struct AppState {
     pub rg_results: Vec<RgResult>,
     pub rg_cursor: usize,
     pub rg_scroll_offset: usize,
+    /// When true, keyboard navigation in rg mode moves the cursor between
+    /// files (left panel) instead of between individual match lines (right
+    /// panel). Toggled with Tab.
+    pub rg_files_focused: bool,
 }
 
 impl AppState {
@@ -216,6 +220,7 @@ impl AppState {
             rg_results: Vec::new(),
             rg_cursor: 0,
             rg_scroll_offset: 0,
+            rg_files_focused: false,
         };
         app.select_first_entry();
         Ok(app)
@@ -248,26 +253,24 @@ impl AppState {
         self.rg_results.clear();
         self.rg_cursor = 0;
         self.rg_scroll_offset = 0;
+        self.rg_files_focused = false;
     }
-
     pub fn exit_rg(&mut self) {
         self.mode = AppMode::Normal;
         self.rg_query.clear();
         self.rg_results.clear();
         self.rg_cursor = 0;
         self.rg_scroll_offset = 0;
+        self.rg_files_focused = false;
     }
-
     pub fn push_rg_char(&mut self, c: char) {
         self.rg_query.push(c);
         self.update_rg();
     }
-
     pub fn pop_rg_char(&mut self) {
         self.rg_query.pop();
         self.update_rg();
     }
-
     pub fn update_rg(&mut self) {
         if self.rg_query.is_empty() {
             self.rg_results.clear();
@@ -275,21 +278,24 @@ impl AppState {
             self.rg_scroll_offset = 0;
             return;
         }
-
         let git_child = std::process::Command::new("git")
             .args(["ls-files", "-z", "--"])
             .arg(&self.root_dir)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
             .spawn();
-
         let output = match git_child {
             Ok(mut git_child) => {
                 let git_stdout = git_child.stdout.take().unwrap();
                 let result = std::process::Command::new("xargs")
                     .args([
-                        "-0", "rg", "--line-number", "--no-heading",
-                        "--color=never", "--", &self.rg_query,
+                        "-0",
+                        "rg",
+                        "--line-number",
+                        "--no-heading",
+                        "--color=never",
+                        "--",
+                        &self.rg_query,
                     ])
                     .stdin(git_stdout)
                     .stdout(std::process::Stdio::piped())
@@ -303,7 +309,6 @@ impl AppState {
             }
             Err(_) => String::new(),
         };
-
         let query_lower = self.rg_query.to_lowercase();
         let query_char_count = self.rg_query.chars().count();
         let mut parsed = Vec::new();
@@ -313,7 +318,6 @@ impl AppState {
                 let path = PathBuf::from(parts[0]);
                 let line_num: usize = parts[1].parse().unwrap_or(0);
                 let content = parts[2];
-
                 let mut indices = Vec::new();
                 let content_lower = content.to_lowercase();
                 let mut start = 0;
@@ -324,7 +328,6 @@ impl AppState {
                     }
                     start = abs + query_char_count;
                 }
-
                 parsed.push(RgResult {
                     path,
                     line_number: line_num,
@@ -337,31 +340,49 @@ impl AppState {
         self.rg_cursor = 0;
         self.rg_scroll_offset = 0;
     }
-
-    pub fn sync_rg_scroll(&mut self, visible_height: usize) {
+    /// Clamp the cursor to valid bounds. The scroll offset (in grouped/visual
+    /// row space, i.e. including file-header rows) is computed directly by
+    /// the render layer, which is the only place that knows the current
+    /// grouping layout.
+    pub fn sync_rg_scroll(&mut self, _visible_height: usize) {
         let len = self.rg_results.len();
         if self.rg_cursor >= len {
             self.rg_cursor = len.saturating_sub(1);
         }
-        if len <= visible_height {
-            self.rg_scroll_offset = 0;
+    }
+    /// Move the cursor to the first match of the previous file group
+    /// (used when the left/Files panel has focus).
+    pub fn rg_cursor_prev_file(&mut self) {
+        let Some(current) = self.rg_results.get(self.rg_cursor).map(|r| r.path.clone()) else {
+            return;
+        };
+        let mut start = self.rg_cursor;
+        while start > 0 && self.rg_results[start - 1].path == current {
+            start -= 1;
+        }
+        if start == 0 {
             return;
         }
-        let top_margin = 2;
-        let bottom_margin = 2;
-        if self.rg_cursor < self.rg_scroll_offset + top_margin
-            && self.rg_scroll_offset > 0
-        {
-            self.rg_scroll_offset = self.rg_cursor.saturating_sub(top_margin);
-        } else if self.rg_cursor + bottom_margin >= self.rg_scroll_offset + visible_height
-            && self.rg_scroll_offset + visible_height < len
-        {
-            self.rg_scroll_offset =
-                (self.rg_cursor + bottom_margin + 1).saturating_sub(visible_height);
+        let prev_path = self.rg_results[start - 1].path.clone();
+        let mut prev_start = start - 1;
+        while prev_start > 0 && self.rg_results[prev_start - 1].path == prev_path {
+            prev_start -= 1;
         }
-        self.rg_scroll_offset = self
-            .rg_scroll_offset
-            .min(len.saturating_sub(visible_height));
+        self.rg_cursor = prev_start;
+    }
+    /// Move the cursor to the first match of the next file group
+    /// (used when the left/Files panel has focus).
+    pub fn rg_cursor_next_file(&mut self) {
+        let Some(current) = self.rg_results.get(self.rg_cursor).map(|r| r.path.clone()) else {
+            return;
+        };
+        let mut idx = self.rg_cursor;
+        while idx < self.rg_results.len() && self.rg_results[idx].path == current {
+            idx += 1;
+        }
+        if idx < self.rg_results.len() {
+            self.rg_cursor = idx;
+        }
     }
 }
 
@@ -537,7 +558,11 @@ impl AppState {
                             .trim()
                             .to_string();
 
-                        GitCommit { display, hash, refs }
+                        GitCommit {
+                            display,
+                            hash,
+                            refs,
+                        }
                     })
                     .collect();
             } else {
@@ -580,20 +605,31 @@ impl AppState {
             if o.status.success() {
                 let stdout = String::from_utf8_lossy(&o.stdout);
                 for line in stdout.lines() {
-                    if line.len() < 3 { continue; }
+                    if line.len() < 3 {
+                        continue;
+                    }
                     let x = line.chars().next().unwrap();
                     let y = line.chars().nth(1).unwrap();
                     let path = line[3..].to_string();
                     let path = path.split(" -> ").last().unwrap_or(&path).to_string();
 
                     if x == '?' && y == '?' {
-                        items.push(GitStatusItem { path, section: GitStatusSection::Untracked });
+                        items.push(GitStatusItem {
+                            path,
+                            section: GitStatusSection::Untracked,
+                        });
                     } else {
                         if x != ' ' && x != '?' {
-                            items.push(GitStatusItem { path: path.clone(), section: GitStatusSection::Staged });
+                            items.push(GitStatusItem {
+                                path: path.clone(),
+                                section: GitStatusSection::Staged,
+                            });
                         }
                         if y != ' ' && y != '?' {
-                            items.push(GitStatusItem { path, section: GitStatusSection::Unstaged });
+                            items.push(GitStatusItem {
+                                path,
+                                section: GitStatusSection::Unstaged,
+                            });
                         }
                     }
                 }
@@ -790,16 +826,12 @@ impl AppState {
         };
 
         let output = match item.section {
-            GitStatusSection::Staged => {
-                std::process::Command::new("git")
-                    .args(["diff", "--cached", "--", &item.path])
-                    .output()
-            }
-            GitStatusSection::Unstaged => {
-                std::process::Command::new("git")
-                    .args(["diff", "--", &item.path])
-                    .output()
-            }
+            GitStatusSection::Staged => std::process::Command::new("git")
+                .args(["diff", "--cached", "--", &item.path])
+                .output(),
+            GitStatusSection::Unstaged => std::process::Command::new("git")
+                .args(["diff", "--", &item.path])
+                .output(),
             GitStatusSection::Untracked => {
                 let abs_path = self.git_file_abs_path(&item.path);
                 match std::fs::read_to_string(&abs_path) {
@@ -851,7 +883,8 @@ impl AppState {
         }
         if self.git_status_diff_cursor < self.git_status_diff_scroll_offset {
             self.git_status_diff_scroll_offset = self.git_status_diff_cursor;
-        } else if self.git_status_diff_cursor >= self.git_status_diff_scroll_offset + visible_height {
+        } else if self.git_status_diff_cursor >= self.git_status_diff_scroll_offset + visible_height
+        {
             self.git_status_diff_scroll_offset = self.git_status_diff_cursor + 1 - visible_height;
         }
         self.git_status_diff_scroll_offset = self
@@ -876,7 +909,15 @@ impl AppState {
         }
 
         let output = std::process::Command::new("git")
-            .args(["diff-tree", "--no-commit-id", "-p", "--root", &hash, "--", &file])
+            .args([
+                "diff-tree",
+                "--no-commit-id",
+                "-p",
+                "--root",
+                &hash,
+                "--",
+                &file,
+            ])
             .output();
 
         self.git_diff_content = match output {
@@ -1215,7 +1256,9 @@ pub fn read_dir_sorted(dir: &PathBuf, respect_gitignore: bool) -> io::Result<Vec
         })
         .collect();
     entries.sort_unstable_by(|a, b| {
-        (!a.is_dir()).cmp(&(!b.is_dir())).then_with(|| a.file_name().cmp(b.file_name()))
+        (!a.is_dir())
+            .cmp(&(!b.is_dir()))
+            .then_with(|| a.file_name().cmp(b.file_name()))
     });
     Ok(entries)
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum AppMode {
     Normal,
     SearchFocused,
@@ -116,6 +116,10 @@ pub struct AppState {
     pub git_status_items: Vec<GitStatusItem>,
     pub git_status_cursor: usize,
     pub git_status_scroll_offset: usize,
+    pub git_status_diff_content: String,
+    pub git_status_diff_scroll_offset: usize,
+    pub git_status_diff_cursor: usize,
+    pub git_status_diff_focused: bool,
     matcher: fuzzy_matcher::skim::SkimMatcherV2,
 }
 
@@ -167,6 +171,10 @@ impl AppState {
             git_status_items: Vec::new(),
             git_status_cursor: 0,
             git_status_scroll_offset: 0,
+            git_status_diff_content: String::new(),
+            git_status_diff_scroll_offset: 0,
+            git_status_diff_cursor: 0,
+            git_status_diff_focused: false,
             matcher: fuzzy_matcher::skim::SkimMatcherV2::default(),
         };
         app.select_first_entry();
@@ -431,8 +439,13 @@ impl AppState {
             self.git_status_cursor = items.len().saturating_sub(1);
         }
         self.git_status_items = items;
+        self.git_status_diff_content = String::new();
+        self.git_status_diff_scroll_offset = 0;
+        self.git_status_diff_cursor = 0;
+        self.git_status_diff_focused = false;
         self.git_base_selected = self.selected.clone();
         self.mode = AppMode::GitStatus;
+        self.fetch_git_status_diff();
     }
 
     pub fn fetch_git_files(&mut self) {
@@ -479,6 +492,86 @@ impl AppState {
         env::current_dir()
             .unwrap_or_else(|_| PathBuf::from("."))
             .join(file)
+    }
+
+    /// Fetch the diff for the currently selected git status item.
+    /// Staged → `git diff --cached`, Unstaged → `git diff`, Untracked → file content.
+    pub fn fetch_git_status_diff(&mut self) {
+        let Some(item) = self.git_status_items.get(self.git_status_cursor).cloned() else {
+            self.git_status_diff_content = "No changes in working tree.".to_string();
+            self.git_status_diff_scroll_offset = 0;
+            self.git_status_diff_cursor = 0;
+            return;
+        };
+
+        let output = match item.section {
+            GitStatusSection::Staged => {
+                std::process::Command::new("git")
+                    .args(["diff", "--cached", "--", &item.path])
+                    .output()
+            }
+            GitStatusSection::Unstaged => {
+                std::process::Command::new("git")
+                    .args(["diff", "--", &item.path])
+                    .output()
+            }
+            GitStatusSection::Untracked => {
+                let abs_path = self.git_file_abs_path(&item.path);
+                match std::fs::read_to_string(&abs_path) {
+                    Ok(content) => {
+                        self.git_status_diff_content = content;
+                    }
+                    Err(_) => {
+                        self.git_status_diff_content =
+                            "Untracked file (binary or unreadable).".to_string();
+                    }
+                }
+                self.git_status_diff_scroll_offset = 0;
+                self.git_status_diff_cursor = 0;
+                return;
+            }
+        };
+
+        self.git_status_diff_content = match output {
+            Ok(o) if o.status.success() => {
+                let text = String::from_utf8_lossy(&o.stdout).to_string();
+                if text.is_empty() {
+                    "(no textual diff)".to_string()
+                } else {
+                    text
+                }
+            }
+            Ok(o) => format!("Error: {}", String::from_utf8_lossy(&o.stderr).trim()),
+            Err(e) => format!("Failed to run git diff: {e}"),
+        };
+        self.git_status_diff_scroll_offset = 0;
+        self.git_status_diff_cursor = 0;
+    }
+
+    /// Keep the diff cursor within the viewport, scrolling when it leaves.
+    pub fn sync_git_status_diff_scroll(&mut self, visible_height: usize) {
+        self.visible_height = visible_height;
+        let len = self.git_status_diff_content.lines().count();
+        if len == 0 {
+            self.git_status_diff_cursor = 0;
+            self.git_status_diff_scroll_offset = 0;
+            return;
+        }
+        if self.git_status_diff_cursor >= len {
+            self.git_status_diff_cursor = len - 1;
+        }
+        if len <= visible_height {
+            self.git_status_diff_scroll_offset = 0;
+            return;
+        }
+        if self.git_status_diff_cursor < self.git_status_diff_scroll_offset {
+            self.git_status_diff_scroll_offset = self.git_status_diff_cursor;
+        } else if self.git_status_diff_cursor >= self.git_status_diff_scroll_offset + visible_height {
+            self.git_status_diff_scroll_offset = self.git_status_diff_cursor + 1 - visible_height;
+        }
+        self.git_status_diff_scroll_offset = self
+            .git_status_diff_scroll_offset
+            .min(len.saturating_sub(visible_height));
     }
     pub fn fetch_git_diff(&mut self) {
         let hash = self

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -29,6 +29,12 @@ pub struct GitStatusItem {
 }
 
 #[derive(Clone)]
+pub struct GitStashItem {
+    pub stash_ref: String,
+    pub message: String,
+}
+
+#[derive(Clone)]
 pub struct SearchResult {
     pub path: PathBuf,
     pub display_name: String,
@@ -121,6 +127,7 @@ pub struct AppState {
     pub git_status_diff_scroll_offset: usize,
     pub git_status_diff_cursor: usize,
     pub git_status_diff_focused: bool,
+    pub git_stash_items: Vec<GitStashItem>,
     matcher: fuzzy_matcher::skim::SkimMatcherV2,
 }
 
@@ -177,6 +184,7 @@ impl AppState {
             git_status_diff_scroll_offset: 0,
             git_status_diff_cursor: 0,
             git_status_diff_focused: false,
+            git_stash_items: Vec::new(),
             matcher: fuzzy_matcher::skim::SkimMatcherV2::default(),
         };
         app.select_first_entry();
@@ -437,8 +445,10 @@ impl AppState {
             }
         }
 
-        if self.git_status_cursor >= items.len() {
-            self.git_status_cursor = items.len().saturating_sub(1);
+        self.fetch_git_stash_list();
+        let total = items.len() + self.git_stash_items.len();
+        if self.git_status_cursor >= total {
+            self.git_status_cursor = total.saturating_sub(1);
         }
         self.git_status_items = items;
         self.git_status_diff_content = String::new();
@@ -448,6 +458,34 @@ impl AppState {
         self.git_base_selected = self.selected.clone();
         self.mode = AppMode::GitStatus;
         self.fetch_git_status_diff();
+    }
+
+    /// Refresh the stash list (used on entering Git Status mode and after
+    /// pushing/popping a stash).
+    pub fn fetch_git_stash_list(&mut self) {
+        let output = std::process::Command::new("git")
+            .args(["stash", "list", "--pretty=format:%gd%x00%s"])
+            .output();
+        let mut items = Vec::new();
+        if let Ok(o) = output {
+            if o.status.success() {
+                let stdout = String::from_utf8_lossy(&o.stdout);
+                for line in stdout.lines() {
+                    let mut parts = line.splitn(2, '\0');
+                    let stash_ref = parts.next().unwrap_or("").to_string();
+                    let message = parts.next().unwrap_or("").to_string();
+                    if !stash_ref.is_empty() {
+                        items.push(GitStashItem { stash_ref, message });
+                    }
+                }
+            }
+        }
+        self.git_stash_items = items;
+    }
+
+    /// Total number of navigable rows in Git Status mode (file items + stashes).
+    pub fn git_status_total_len(&self) -> usize {
+        self.git_status_items.len() + self.git_stash_items.len()
     }
 
     pub fn fetch_git_files(&mut self) {
@@ -499,6 +537,34 @@ impl AppState {
     /// Fetch the diff for the currently selected git status item.
     /// Staged → `git diff --cached`, Unstaged → `git diff`, Untracked → file content.
     pub fn fetch_git_status_diff(&mut self) {
+        let items_len = self.git_status_items.len();
+        if self.git_status_cursor >= items_len {
+            let stash_idx = self.git_status_cursor - items_len;
+            let Some(stash) = self.git_stash_items.get(stash_idx).cloned() else {
+                self.git_status_diff_content = "No changes in working tree.".to_string();
+                self.git_status_diff_scroll_offset = 0;
+                self.git_status_diff_cursor = 0;
+                return;
+            };
+            let output = std::process::Command::new("git")
+                .args(["stash", "show", "-p", &stash.stash_ref])
+                .output();
+            self.git_status_diff_content = match output {
+                Ok(o) if o.status.success() => {
+                    let text = String::from_utf8_lossy(&o.stdout).to_string();
+                    if text.is_empty() {
+                        "(no textual diff)".to_string()
+                    } else {
+                        text
+                    }
+                }
+                Ok(o) => format!("Error: {}", String::from_utf8_lossy(&o.stderr).trim()),
+                Err(e) => format!("Failed to run git stash show: {e}"),
+            };
+            self.git_status_diff_scroll_offset = 0;
+            self.git_status_diff_cursor = 0;
+            return;
+        }
         let Some(item) = self.git_status_items.get(self.git_status_cursor).cloned() else {
             self.git_status_diff_content = "No changes in working tree.".to_string();
             self.git_status_diff_scroll_offset = 0;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -12,6 +12,20 @@ pub enum AppMode {
     SearchFocused,
     SearchNavigating,
     GitTree,
+    GitStatus,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum GitStatusSection {
+    Staged,
+    Unstaged,
+    Untracked,
+}
+
+#[derive(Clone)]
+pub struct GitStatusItem {
+    pub path: String,
+    pub section: GitStatusSection,
 }
 
 #[derive(Clone)]
@@ -92,13 +106,16 @@ pub struct AppState {
     pub git_files_scroll_offset: usize,
     pub git_panel_focused: bool,
     pub git_marked_commits: HashSet<String>,
-    git_base_selected: HashSet<PathBuf>,
+    pub(crate) git_base_selected: HashSet<PathBuf>,
     git_diff_cache: HashMap<String, Vec<String>>,
     pub show_git_diff: bool,
     pub git_diff_content: String,
     pub git_diff_scroll_offset: usize,
     pub git_diff_cursor: usize,
     dir_select_cache: RefCell<HashMap<PathBuf, bool>>,
+    pub git_status_items: Vec<GitStatusItem>,
+    pub git_status_cursor: usize,
+    pub git_status_scroll_offset: usize,
     matcher: fuzzy_matcher::skim::SkimMatcherV2,
 }
 
@@ -147,6 +164,9 @@ impl AppState {
             git_diff_scroll_offset: 0,
             git_diff_cursor: 0,
             dir_select_cache: RefCell::new(HashMap::new()),
+            git_status_items: Vec::new(),
+            git_status_cursor: 0,
+            git_status_scroll_offset: 0,
             matcher: fuzzy_matcher::skim::SkimMatcherV2::default(),
         };
         app.select_first_entry();
@@ -174,7 +194,7 @@ impl AppState {
 
 // SelectionExt
 impl AppState {
-    fn invalidate_caches(&mut self) {
+    pub(crate) fn invalidate_caches(&mut self) {
         self.selected_file_count_cache = None;
         self.selected_loc_cache = None;
         self.dir_select_cache.get_mut().clear();
@@ -377,6 +397,44 @@ impl AppState {
         self.mode = AppMode::GitTree;
     }
 
+    pub fn enter_git_status_mode(&mut self) {
+        let output = std::process::Command::new("git")
+            .args(["status", "--porcelain=v1"])
+            .output();
+
+        let mut items = Vec::new();
+        if let Ok(o) = output {
+            if o.status.success() {
+                let stdout = String::from_utf8_lossy(&o.stdout);
+                for line in stdout.lines() {
+                    if line.len() < 3 { continue; }
+                    let x = line.chars().next().unwrap();
+                    let y = line.chars().nth(1).unwrap();
+                    let path = line[3..].to_string();
+                    let path = path.split(" -> ").last().unwrap_or(&path).to_string();
+
+                    if x == '?' && y == '?' {
+                        items.push(GitStatusItem { path, section: GitStatusSection::Untracked });
+                    } else {
+                        if x != ' ' && x != '?' {
+                            items.push(GitStatusItem { path: path.clone(), section: GitStatusSection::Staged });
+                        }
+                        if y != ' ' && y != '?' {
+                            items.push(GitStatusItem { path, section: GitStatusSection::Unstaged });
+                        }
+                    }
+                }
+            }
+        }
+
+        if self.git_status_cursor >= items.len() {
+            self.git_status_cursor = items.len().saturating_sub(1);
+        }
+        self.git_status_items = items;
+        self.git_base_selected = self.selected.clone();
+        self.mode = AppMode::GitStatus;
+    }
+
     pub fn fetch_git_files(&mut self) {
         let hash = self
             .git_commits
@@ -417,7 +475,7 @@ impl AppState {
         files
     }
 
-    fn git_file_abs_path(&self, file: &str) -> PathBuf {
+    pub(crate) fn git_file_abs_path(&self, file: &str) -> PathBuf {
         env::current_dir()
             .unwrap_or_else(|_| PathBuf::from("."))
             .join(file)

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -27,6 +27,7 @@ pub struct SearchResult {
 pub struct GitCommit {
     pub display: String,
     pub hash: String,
+    pub refs: String,
 }
 
 /// Detect whether `dir` is inside a git work-tree by walking up for a `.git` entry.
@@ -300,7 +301,7 @@ impl AppState {
 
     pub fn enter_git_tree_mode(&mut self) {
         if let Ok(output) = std::process::Command::new("git")
-            .args(["log", "--graph", "--pretty=format:%H%x00%s"])
+            .args(["log", "--graph", "--pretty=format:%H%x00%d%x00%s"])
             .output()
         {
             if output.status.success() {
@@ -308,8 +309,9 @@ impl AppState {
                 self.git_commits = stdout
                     .lines()
                     .map(|line| {
-                        let mut parts = line.splitn(2, '\0');
+                        let mut parts = line.splitn(3, '\0');
                         let graph_hash = parts.next().unwrap_or("");
+                        let refs_raw = parts.next().unwrap_or("");
                         let message = parts.next().unwrap_or("");
 
                         let long_hash = graph_hash
@@ -335,19 +337,28 @@ impl AppState {
                             format!("{} {}", display_graph, message)
                         };
 
-                        GitCommit { display, hash }
+                        let refs = refs_raw
+                            .trim()
+                            .trim_start_matches('(')
+                            .trim_end_matches(')')
+                            .trim()
+                            .to_string();
+
+                        GitCommit { display, hash, refs }
                     })
                     .collect();
             } else {
                 self.git_commits = vec![GitCommit {
                     display: "Failed to load git log. Not a git repository?".to_string(),
                     hash: String::new(),
+                    refs: String::new(),
                 }];
             }
         } else {
             self.git_commits = vec![GitCommit {
                 display: "Failed to execute git command.".to_string(),
                 hash: String::new(),
+                refs: String::new(),
             }];
         }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -128,6 +128,7 @@ pub struct AppState {
     pub git_status_diff_cursor: usize,
     pub git_status_diff_focused: bool,
     pub git_stash_items: Vec<GitStashItem>,
+    pub pending_stash_pop: Option<String>,
     matcher: fuzzy_matcher::skim::SkimMatcherV2,
 }
 
@@ -185,6 +186,7 @@ impl AppState {
             git_status_diff_cursor: 0,
             git_status_diff_focused: false,
             git_stash_items: Vec::new(),
+            pending_stash_pop: None,
             matcher: fuzzy_matcher::skim::SkimMatcherV2::default(),
         };
         app.select_first_entry();
@@ -456,6 +458,7 @@ impl AppState {
         self.git_status_diff_cursor = 0;
         self.git_status_diff_focused = false;
         self.git_base_selected = self.selected.clone();
+        self.pending_stash_pop = None;
         self.mode = AppMode::GitStatus;
         self.fetch_git_status_diff();
     }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -162,7 +162,10 @@ fn handle_git_tree(
     message: &mut String,
 ) -> Option<Vec<String>> {
     match key_event.code {
-        KeyCode::Tab | KeyCode::Char('2') | KeyCode::Esc => {
+        KeyCode::Tab => {
+            app.git_panel_focused = !app.git_panel_focused;
+        }
+        KeyCode::Char('2') | KeyCode::Esc => {
             app.mode = AppMode::Normal;
         }
         KeyCode::Char('1') => {

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -45,6 +45,22 @@ fn handle_git_status(
         }
         return None;
     }
+    if let Some(branch) = app.pending_branch_switch.clone() {
+        match key_event.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                let _ = std::process::Command::new("git")
+                    .args(["switch", &branch])
+                    .output();
+                app.pending_branch_switch = None;
+                app.enter_git_status_mode();
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                app.pending_branch_switch = None;
+            }
+            _ => {}
+        }
+        return None;
+    }
     match key_event.code {
         KeyCode::Tab => {
             app.git_status_diff_focused = !app.git_status_diff_focused;
@@ -109,12 +125,19 @@ fn handle_git_status(
         KeyCode::Enter => {
             let items_len = app.git_status_items.len();
             if app.git_status_cursor >= items_len {
-                if let Some(stash) = app
-                    .git_stash_items
-                    .get(app.git_status_cursor - items_len)
-                    .cloned()
-                {
-                    app.pending_stash_pop = Some(stash.stash_ref.clone());
+                let after_items_idx = app.git_status_cursor - items_len;
+                let stash_len = app.git_stash_items.len();
+                if after_items_idx < stash_len {
+                    if let Some(stash) = app.git_stash_items.get(after_items_idx).cloned() {
+                        app.pending_stash_pop = Some(stash.stash_ref.clone());
+                    }
+                } else {
+                    let branch_idx = after_items_idx - stash_len;
+                    if let Some(branch) = app.git_branch_items.get(branch_idx).cloned() {
+                        if !branch.is_current {
+                            app.pending_branch_switch = Some(branch.name.clone());
+                        }
+                    }
                 }
             }
         }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -18,6 +18,8 @@ pub fn handle_key_event(
         AppMode::Normal => handle_normal(app, key_event, message),
         AppMode::GitTree => handle_git_tree(app, key_event, message),
         AppMode::GitStatus => handle_git_status(app, key_event, message),
+        AppMode::RgFocused => handle_rg_focused(app, key_event),
+        AppMode::RgNavigating => handle_rg_navigating(app, key_event, message),
     }
 }
 
@@ -276,6 +278,101 @@ fn handle_git_tree(
     None
 }
 
+fn handle_rg_focused(app: &mut AppState, key_event: KeyEvent) -> Option<Vec<String>> {
+    match key_event.code {
+        KeyCode::Esc => {
+            app.exit_rg();
+        }
+        KeyCode::Backspace => {
+            app.pop_rg_char();
+        }
+        KeyCode::Enter | KeyCode::Down | KeyCode::Up => {
+            if !app.rg_results.is_empty() {
+                app.mode = AppMode::RgNavigating;
+            }
+        }
+        KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            return Some(vec![]);
+        }
+        KeyCode::Char(c) => {
+            app.push_rg_char(c);
+        }
+        _ => {}
+    }
+    None
+}
+
+fn handle_rg_navigating(
+    app: &mut AppState,
+    key_event: KeyEvent,
+    message: &mut String,
+) -> Option<Vec<String>> {
+    match key_event.code {
+        KeyCode::Char('q') => return Some(vec![]),
+        KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            return Some(vec![]);
+        }
+        KeyCode::Char('c') => {
+            if app.selected.is_empty() {
+                *message = "No files or directories selected!".to_string();
+            } else {
+                return Some(app.collect_selected_paths());
+            }
+        }
+        KeyCode::Char('y') => {
+            if let Some(result) = app.rg_results.get(app.rg_cursor) {
+                let text = format!(
+                    "{}:{}:{}",
+                    result.path.display(),
+                    result.line_number,
+                    result.line_content
+                );
+                match crate::tui::copy_text_to_clipboard(&text) {
+                    Ok(()) => *message = "Copied result to clipboard.".to_string(),
+                    Err(e) => *message = format!("Failed to copy: {e}"),
+                }
+            }
+        }
+        KeyCode::Char('m') => {
+            app.aider = !app.aider;
+            message.clear();
+        }
+        KeyCode::Char('\'') => {
+            app.mode = AppMode::RgFocused;
+        }
+        KeyCode::Esc => {
+            app.exit_rg();
+        }
+        KeyCode::Enter | KeyCode::Char(' ') => {
+            if let Some(result) = app.rg_results.get(app.rg_cursor) {
+                let path = result.path.clone();
+                app.toggle_selection(path, false);
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') if app.rg_cursor > 0 => {
+            app.rg_cursor -= 1;
+        }
+        KeyCode::Down | KeyCode::Char('j')
+            if app.rg_cursor + 1 < app.rg_results.len() =>
+        {
+            app.rg_cursor += 1;
+        }
+        KeyCode::Char('p') => {
+            let added = app.restore_last_selection();
+            *message = if added > 0 {
+                format!(
+                    "Restored last selection (+{added} file{}).",
+                    if added == 1 { "" } else { "s" }
+                )
+            } else {
+                "No previous selection in this session.".to_string()
+            };
+        }
+        _ => {}
+    }
+    None
+}
+
 fn handle_search_focused(app: &mut AppState, key_event: KeyEvent) -> Option<Vec<String>> {
     match key_event.code {
         KeyCode::Esc => {
@@ -499,6 +596,9 @@ fn handle_normal(
         }
         KeyCode::Char('/') => {
             app.enter_search();
+        }
+        KeyCode::Char('\'') => {
+            app.enter_rg();
         }
         KeyCode::Char('f') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
             app.enter_search();

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -2,7 +2,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButto
 use ratatui::layout::Position;
 use std::path::PathBuf;
 
-use crate::tui::app::{AppMode, AppState};
+use crate::tui::app::{AppMode, AppState, GitStatusSection};
 
 pub fn handle_key_event(
     app: &mut AppState,
@@ -17,7 +17,78 @@ pub fn handle_key_event(
         AppMode::SearchNavigating => handle_search_navigating(app, key_event, message),
         AppMode::Normal => handle_normal(app, key_event, message),
         AppMode::GitTree => handle_git_tree(app, key_event, message),
+        AppMode::GitStatus => handle_git_status(app, key_event, message),
     }
+}
+
+fn handle_git_status(
+    app: &mut AppState,
+    key_event: KeyEvent,
+    message: &mut String,
+) -> Option<Vec<String>> {
+    match key_event.code {
+        KeyCode::Tab | KeyCode::Char('1') | KeyCode::Esc => {
+            app.mode = AppMode::Normal;
+        }
+        KeyCode::Char('2') => {
+            app.enter_git_tree_mode();
+        }
+        KeyCode::Char('q') => return Some(vec![]),
+        KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            return Some(vec![])
+        }
+        KeyCode::Char('c') => {
+            if app.selected.is_empty() {
+                *message = "No files or directories selected!".to_string();
+            } else {
+                return Some(app.collect_selected_paths());
+            }
+        }
+        KeyCode::Char('s') => {
+            if let Some(item) = app.git_status_items.get(app.git_status_cursor).cloned() {
+                let path = &item.path;
+                match item.section {
+                    GitStatusSection::Staged => {
+                        let _ = std::process::Command::new("git")
+                            .args(["restore", "--staged", path])
+                            .output();
+                    }
+                    GitStatusSection::Unstaged | GitStatusSection::Untracked => {
+                        let _ = std::process::Command::new("git")
+                            .args(["add", path])
+                            .output();
+                    }
+                }
+                let old_cursor = app.git_status_cursor;
+                app.enter_git_status_mode();
+                app.git_status_cursor = old_cursor.min(app.git_status_items.len().saturating_sub(1));
+            }
+        }
+        KeyCode::Char(' ') => {
+            if let Some(item) = app.git_status_items.get(app.git_status_cursor).cloned() {
+                let path = app.git_file_abs_path(&item.path);
+                app.invalidate_caches();
+                if app.selected.remove(&path) {
+                    app.git_base_selected.remove(&path);
+                } else {
+                    app.selected.insert(path.clone());
+                    app.git_base_selected.insert(path);
+                }
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            if app.git_status_cursor > 0 {
+                app.git_status_cursor -= 1;
+            }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if app.git_status_cursor + 1 < app.git_status_items.len() {
+                app.git_status_cursor += 1;
+            }
+        }
+        _ => {}
+    }
+    None
 }
 
 fn handle_git_tree(
@@ -26,11 +97,11 @@ fn handle_git_tree(
     message: &mut String,
 ) -> Option<Vec<String>> {
     match key_event.code {
-        KeyCode::Tab => {
-            app.git_panel_focused = !app.git_panel_focused;
-        }
-        KeyCode::Esc => {
+        KeyCode::Tab | KeyCode::Char('2') | KeyCode::Esc => {
             app.mode = AppMode::Normal;
+        }
+        KeyCode::Char('1') => {
+            app.enter_git_status_mode();
         }
         KeyCode::Char('q') => return Some(vec![]),
         KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -240,7 +311,7 @@ pub fn handle_mouse_event(app: &mut AppState, mouse: MouseEvent, _message: &mut 
                 }
             }
         }
-        MouseEventKind::ScrollDown => {
+       MouseEventKind::ScrollDown => {
             if app.mode == AppMode::Normal {
                 app.tree_state.scroll_down(1);
             } else if app.mode == AppMode::GitTree {
@@ -251,6 +322,10 @@ pub fn handle_mouse_event(app: &mut AppState, mouse: MouseEvent, _message: &mut 
                     }
                 } else if app.git_files_cursor + 1 < app.git_files.len() {
                     app.git_files_cursor += 1;
+                }
+            } else if app.mode == AppMode::GitStatus {
+                if app.git_status_cursor + 1 < app.git_status_items.len() {
+                    app.git_status_cursor += 1;
                 }
             } else if app.search_cursor + 1 < app.search_results.len() {
                 app.search_cursor += 1;
@@ -268,6 +343,10 @@ pub fn handle_mouse_event(app: &mut AppState, mouse: MouseEvent, _message: &mut 
                     }
                 } else if app.git_files_cursor > 0 {
                     app.git_files_cursor -= 1;
+                }
+            } else if app.mode == AppMode::GitStatus {
+                if app.git_status_cursor > 0 {
+                    app.git_status_cursor -= 1;
                 }
             } else if app.search_cursor > 0 {
                 app.search_cursor -= 1;
@@ -364,8 +443,11 @@ fn handle_normal(
                 "No previous selection in this session.".to_string()
             };
         }
-        KeyCode::Tab => {
+       KeyCode::Tab | KeyCode::Char('2') => {
             app.enter_git_tree_mode();
+        }
+        KeyCode::Char('1') => {
+            app.enter_git_status_mode();
         }
         _ => {}
     }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -325,22 +325,31 @@ fn handle_rg_navigating(
         }
         KeyCode::Char('y') => {
             if app.rg_files_focused {
-                // Left panel: copy every match belonging to the highlighted
-                // file, since a single right-panel line wouldn't correspond
-                // to what's actually highlighted here.
-                let files = app.rg_match_files();
-                if let Some(path) = files.get(app.rg_file_cursor) {
-                    let text: String = app
-                        .rg_results
-                        .iter()
-                        .filter(|r| &r.path == path)
-                        .map(|r| {
-                            format!("{}:{}:{}", r.path.display(), r.line_number, r.line_content)
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n");
+                // Left panel: copy every match line belonging to *selected*
+                // files (those marked ✓ via Space/Enter). This gathers all
+                // "selection lines" from the right panel across every
+                // selected file — not just the highlighted file's matches.
+                let selected_matches: Vec<String> = app
+                    .rg_results
+                    .iter()
+                    .filter(|r| app.selected.contains(&r.path))
+                    .map(|r| {
+                        format!("{}:{}:{}", r.path.display(), r.line_number, r.line_content)
+                    })
+                    .collect();
+                if selected_matches.is_empty() {
+                    *message =
+                        "No selected files — press Space on a file/match to select first."
+                            .to_string();
+                } else {
+                    let count = selected_matches.len();
+                    let text = selected_matches.join("\n");
                     match crate::tui::copy_text_to_clipboard(&text) {
-                        Ok(()) => *message = "Copied file matches to clipboard.".to_string(),
+                        Ok(()) => {
+                            *message = format!(
+                                "Copied {count} selected match line(s) to clipboard."
+                            );
+                        }
                         Err(e) => *message = format!("Failed to copy: {e}"),
                     }
                 }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -26,6 +26,25 @@ fn handle_git_status(
     key_event: KeyEvent,
     message: &mut String,
 ) -> Option<Vec<String>> {
+    if let Some(stash_ref) = app.pending_stash_pop.clone() {
+        match key_event.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                let _ = std::process::Command::new("git")
+                    .args(["stash", "pop", &stash_ref])
+                    .output();
+                app.pending_stash_pop = None;
+                let old_cursor = app.git_status_cursor;
+                app.enter_git_status_mode();
+                app.git_status_cursor = old_cursor.min(app.git_status_total_len().saturating_sub(1));
+                app.fetch_git_status_diff();
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                app.pending_stash_pop = None;
+            }
+            _ => {}
+        }
+        return None;
+    }
     match key_event.code {
         KeyCode::Tab => {
             app.git_status_diff_focused = !app.git_status_diff_focused;
@@ -95,14 +114,7 @@ fn handle_git_status(
                     .get(app.git_status_cursor - items_len)
                     .cloned()
                 {
-                    let _ = std::process::Command::new("git")
-                        .args(["stash", "pop", &stash.stash_ref])
-                        .output();
-                    let old_cursor = app.git_status_cursor;
-                    app.enter_git_status_mode();
-                    app.git_status_cursor =
-                        old_cursor.min(app.git_status_total_len().saturating_sub(1));
-                    app.fetch_git_status_diff();
+                    app.pending_stash_pop = Some(stash.stash_ref.clone());
                 }
             }
         }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -78,6 +78,34 @@ fn handle_git_status(
                 app.fetch_git_status_diff();
             }
         }
+        KeyCode::Char('z') => {
+            let _ = std::process::Command::new("git")
+                .args(["stash", "push"])
+                .output();
+            let old_cursor = app.git_status_cursor;
+            app.enter_git_status_mode();
+            app.git_status_cursor = old_cursor.min(app.git_status_total_len().saturating_sub(1));
+            app.fetch_git_status_diff();
+        }
+        KeyCode::Enter => {
+            let items_len = app.git_status_items.len();
+            if app.git_status_cursor >= items_len {
+                if let Some(stash) = app
+                    .git_stash_items
+                    .get(app.git_status_cursor - items_len)
+                    .cloned()
+                {
+                    let _ = std::process::Command::new("git")
+                        .args(["stash", "pop", &stash.stash_ref])
+                        .output();
+                    let old_cursor = app.git_status_cursor;
+                    app.enter_git_status_mode();
+                    app.git_status_cursor =
+                        old_cursor.min(app.git_status_total_len().saturating_sub(1));
+                    app.fetch_git_status_diff();
+                }
+            }
+        }
         KeyCode::Char(' ') => {
             if let Some(item) = app.git_status_items.get(app.git_status_cursor).cloned() {
                 let path = app.git_file_abs_path(&item.path);
@@ -106,7 +134,7 @@ fn handle_git_status(
                 if app.git_status_diff_cursor + 1 < len {
                     app.git_status_diff_cursor += 1;
                 }
-            } else if app.git_status_cursor + 1 < app.git_status_items.len() {
+            } else if app.git_status_cursor + 1 < app.git_status_total_len() {
                 app.git_status_cursor += 1;
                 app.fetch_git_status_diff();
             }
@@ -362,7 +390,7 @@ pub fn handle_mouse_event(app: &mut AppState, mouse: MouseEvent, _message: &mut 
                     if app.git_status_diff_cursor + 1 < len {
                         app.git_status_diff_cursor += 1;
                     }
-                } else if app.git_status_cursor + 1 < app.git_status_items.len() {
+                } else if app.git_status_cursor + 1 < app.git_status_total_len() {
                     app.git_status_cursor += 1;
                     app.fetch_git_status_diff();
                 }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -27,7 +27,16 @@ fn handle_git_status(
     message: &mut String,
 ) -> Option<Vec<String>> {
     match key_event.code {
-        KeyCode::Tab | KeyCode::Char('1') | KeyCode::Esc => {
+        KeyCode::Tab => {
+            app.git_status_diff_focused = !app.git_status_diff_focused;
+        }
+        KeyCode::Left | KeyCode::Char('h') => {
+            app.git_status_diff_focused = false;
+        }
+        KeyCode::Right | KeyCode::Char('l') => {
+            app.git_status_diff_focused = true;
+        }
+        KeyCode::Char('1') | KeyCode::Esc => {
             app.mode = AppMode::Normal;
         }
         KeyCode::Char('2') => {
@@ -62,6 +71,7 @@ fn handle_git_status(
                 let old_cursor = app.git_status_cursor;
                 app.enter_git_status_mode();
                 app.git_status_cursor = old_cursor.min(app.git_status_items.len().saturating_sub(1));
+                app.fetch_git_status_diff();
             }
         }
         KeyCode::Char(' ') => {
@@ -77,13 +87,24 @@ fn handle_git_status(
             }
         }
         KeyCode::Up | KeyCode::Char('k') => {
-            if app.git_status_cursor > 0 {
+            if app.git_status_diff_focused {
+                if app.git_status_diff_cursor > 0 {
+                    app.git_status_diff_cursor -= 1;
+                }
+            } else if app.git_status_cursor > 0 {
                 app.git_status_cursor -= 1;
+                app.fetch_git_status_diff();
             }
         }
         KeyCode::Down | KeyCode::Char('j') => {
-            if app.git_status_cursor + 1 < app.git_status_items.len() {
+            if app.git_status_diff_focused {
+                let len = app.git_status_diff_content.lines().count();
+                if app.git_status_diff_cursor + 1 < len {
+                    app.git_status_diff_cursor += 1;
+                }
+            } else if app.git_status_cursor + 1 < app.git_status_items.len() {
                 app.git_status_cursor += 1;
+                app.fetch_git_status_diff();
             }
         }
         _ => {}
@@ -324,8 +345,14 @@ pub fn handle_mouse_event(app: &mut AppState, mouse: MouseEvent, _message: &mut 
                     app.git_files_cursor += 1;
                 }
             } else if app.mode == AppMode::GitStatus {
-                if app.git_status_cursor + 1 < app.git_status_items.len() {
+                if app.git_status_diff_focused {
+                    let len = app.git_status_diff_content.lines().count();
+                    if app.git_status_diff_cursor + 1 < len {
+                        app.git_status_diff_cursor += 1;
+                    }
+                } else if app.git_status_cursor + 1 < app.git_status_items.len() {
                     app.git_status_cursor += 1;
+                    app.fetch_git_status_diff();
                 }
             } else if app.search_cursor + 1 < app.search_results.len() {
                 app.search_cursor += 1;
@@ -345,8 +372,13 @@ pub fn handle_mouse_event(app: &mut AppState, mouse: MouseEvent, _message: &mut 
                     app.git_files_cursor -= 1;
                 }
             } else if app.mode == AppMode::GitStatus {
-                if app.git_status_cursor > 0 {
+                if app.git_status_diff_focused {
+                    if app.git_status_diff_cursor > 0 {
+                        app.git_status_diff_cursor -= 1;
+                    }
+                } else if app.git_status_cursor > 0 {
                     app.git_status_cursor -= 1;
+                    app.fetch_git_status_diff();
                 }
             } else if app.search_cursor > 0 {
                 app.search_cursor -= 1;

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -289,6 +289,8 @@ fn handle_rg_focused(app: &mut AppState, key_event: KeyEvent) -> Option<Vec<Stri
         KeyCode::Enter | KeyCode::Down | KeyCode::Up => {
             if !app.rg_results.is_empty() {
                 app.mode = AppMode::RgNavigating;
+                // Navigation always starts on the Files (left) panel.
+                app.rg_files_focused = true;
             }
         }
         KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -301,7 +303,6 @@ fn handle_rg_focused(app: &mut AppState, key_event: KeyEvent) -> Option<Vec<Stri
     }
     None
 }
-
 fn handle_rg_navigating(
     app: &mut AppState,
     key_event: KeyEvent,
@@ -323,7 +324,28 @@ fn handle_rg_navigating(
             app.rg_files_focused = !app.rg_files_focused;
         }
         KeyCode::Char('y') => {
-            if let Some(result) = app.rg_results.get(app.rg_cursor) {
+            if app.rg_files_focused {
+                // Left panel: copy every match belonging to the highlighted
+                // file, since a single right-panel line wouldn't correspond
+                // to what's actually highlighted here.
+                let files = app.rg_match_files();
+                if let Some(path) = files.get(app.rg_file_cursor) {
+                    let text: String = app
+                        .rg_results
+                        .iter()
+                        .filter(|r| &r.path == path)
+                        .map(|r| {
+                            format!("{}:{}:{}", r.path.display(), r.line_number, r.line_content)
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    match crate::tui::copy_text_to_clipboard(&text) {
+                        Ok(()) => *message = "Copied file matches to clipboard.".to_string(),
+                        Err(e) => *message = format!("Failed to copy: {e}"),
+                    }
+                }
+            } else if let Some(result) = app.rg_results.get(app.rg_cursor) {
+                // Right panel: copy just the single highlighted match line.
                 let text = format!(
                     "{}:{}:{}",
                     result.path.display(),
@@ -347,21 +369,27 @@ fn handle_rg_navigating(
             app.exit_rg();
         }
         KeyCode::Enter | KeyCode::Char(' ') => {
-            if let Some(result) = app.rg_results.get(app.rg_cursor) {
+            if app.rg_files_focused {
+                let files = app.rg_match_files();
+                if let Some(path) = files.get(app.rg_file_cursor) {
+                    let path = path.clone();
+                    app.toggle_selection(path, false);
+                }
+            } else if let Some(result) = app.rg_results.get(app.rg_cursor) {
                 let path = result.path.clone();
                 app.toggle_selection(path, false);
             }
         }
         KeyCode::Up | KeyCode::Char('k') => {
             if app.rg_files_focused {
-                app.rg_cursor_prev_file();
+                app.rg_file_cursor_up();
             } else if app.rg_cursor > 0 {
                 app.rg_cursor -= 1;
             }
         }
         KeyCode::Down | KeyCode::Char('j') => {
             if app.rg_files_focused {
-                app.rg_cursor_next_file();
+                app.rg_file_cursor_down();
             } else if app.rg_cursor + 1 < app.rg_results.len() {
                 app.rg_cursor += 1;
             }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -53,6 +53,10 @@ fn handle_git_status(
                 return Some(app.collect_selected_paths());
             }
         }
+        KeyCode::Char('m') => {
+            app.aider = !app.aider;
+            message.clear();
+        }
         KeyCode::Char('s') => {
             if let Some(item) = app.git_status_items.get(app.git_status_cursor).cloned() {
                 let path = &item.path;
@@ -134,6 +138,10 @@ fn handle_git_tree(
             } else {
                 return Some(app.collect_selected_paths());
             }
+        }
+        KeyCode::Char('m') => {
+            app.aider = !app.aider;
+            message.clear();
         }
         KeyCode::Char('p') => {
             let added = app.restore_last_selection();
@@ -237,6 +245,10 @@ fn handle_search_navigating(
             } else {
                 return Some(app.collect_selected_paths());
             }
+        }
+        KeyCode::Char('m') => {
+            app.aider = !app.aider;
+            message.clear();
         }
         KeyCode::Char('/') => {
             app.mode = AppMode::SearchFocused;
@@ -414,6 +426,10 @@ fn handle_normal(
             } else {
                 return Some(app.collect_selected_paths());
             }
+        }
+        KeyCode::Char('m') => {
+            app.aider = !app.aider;
+            message.clear();
         }
         KeyCode::Char('/') => {
             app.enter_search();

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -319,6 +319,9 @@ fn handle_rg_navigating(
                 return Some(app.collect_selected_paths());
             }
         }
+        KeyCode::Tab => {
+            app.rg_files_focused = !app.rg_files_focused;
+        }
         KeyCode::Char('y') => {
             if let Some(result) = app.rg_results.get(app.rg_cursor) {
                 let text = format!(
@@ -349,13 +352,19 @@ fn handle_rg_navigating(
                 app.toggle_selection(path, false);
             }
         }
-        KeyCode::Up | KeyCode::Char('k') if app.rg_cursor > 0 => {
-            app.rg_cursor -= 1;
+        KeyCode::Up | KeyCode::Char('k') => {
+            if app.rg_files_focused {
+                app.rg_cursor_prev_file();
+            } else if app.rg_cursor > 0 {
+                app.rg_cursor -= 1;
+            }
         }
-        KeyCode::Down | KeyCode::Char('j')
-            if app.rg_cursor + 1 < app.rg_results.len() =>
-        {
-            app.rg_cursor += 1;
+        KeyCode::Down | KeyCode::Char('j') => {
+            if app.rg_files_focused {
+                app.rg_cursor_next_file();
+            } else if app.rg_cursor + 1 < app.rg_results.len() {
+                app.rg_cursor += 1;
+            }
         }
         KeyCode::Char('p') => {
             let added = app.restore_last_selection();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -89,10 +89,16 @@ fn tui_main(
         if needs_redraw {
             // Search mode manages its own cursor scrolling; tree widget self-manages.
             if app.mode != AppMode::Normal {
-                if app.mode == AppMode::GitTree {
-                    app.sync_git_scroll(app.visible_height);
-                } else {
-                    app.sync_search_scroll(app.visible_height);
+                match app.mode {
+                    AppMode::GitTree => {
+                        app.sync_git_scroll(app.visible_height);
+                    }
+                    AppMode::GitStatus => {
+                        app.sync_git_status_diff_scroll(app.visible_height);
+                    }
+                    _ => {
+                        app.sync_search_scroll(app.visible_height);
+                    }
                 }
             }
             let file_count = app.selected_file_count();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -5,6 +5,7 @@ mod theme;
 
 use anyhow::{Context, Result};
 use crossterm::{
+    cursor::{Hide, Show},
     event::{self, Event},
     execute as crossterm_execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -61,15 +62,19 @@ pub struct TuiOutcome {
 pub fn run_tui(relative: bool, no_path: bool, aider: bool) -> Result<TuiOutcome> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    crossterm_execute!(stdout, EnterAlternateScreen, crossterm::event::EnableMouseCapture)?;
+    crossterm_execute!(
+        stdout,
+        EnterAlternateScreen,
+        crossterm::event::EnableMouseCapture,
+        Hide
+    )?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
-
     let res = tui_main(&mut terminal, relative, no_path, aider);
-
     disable_raw_mode()?;
     crossterm_execute!(
         io::stdout(),
+        Show,
         LeaveAlternateScreen,
         crossterm::event::DisableMouseCapture
     )?;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -55,16 +55,17 @@ pub struct TuiOutcome {
     pub paths: Vec<String>,
     pub relative: bool,
     pub no_path: bool,
+    pub aider: bool,
 }
 
-pub fn run_tui(relative: bool, no_path: bool) -> Result<TuiOutcome> {
+pub fn run_tui(relative: bool, no_path: bool, aider: bool) -> Result<TuiOutcome> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     crossterm_execute!(stdout, EnterAlternateScreen, crossterm::event::EnableMouseCapture)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let res = tui_main(&mut terminal, relative, no_path);
+    let res = tui_main(&mut terminal, relative, no_path, aider);
 
     disable_raw_mode()?;
     crossterm_execute!(
@@ -79,8 +80,9 @@ fn tui_main(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     relative: bool,
     no_path: bool,
+    aider: bool,
 ) -> Result<TuiOutcome> {
-    let mut app = AppState::new(relative, no_path).context("Failed to read current directory")?;
+    let mut app = AppState::new(relative, no_path, aider).context("Failed to read current directory")?;
     let mut message = String::new();
     let mut needs_redraw = true;
     let mut rendered_height: u16 = 0;
@@ -125,6 +127,7 @@ fn tui_main(
                         paths,
                         relative: app.relative,
                         no_path: app.no_path,
+                        aider: app.aider,
                     });
                 }
                 needs_redraw = true;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -52,6 +52,15 @@ pub(super) fn load_last_selection() -> Option<HashSet<PathBuf>> {
     if paths.is_empty() { None } else { Some(paths) }
 }
 
+pub fn copy_text_to_clipboard(text: &str) -> anyhow::Result<()> {
+    use std::io::Write;
+    let mut handler = crate::output_handler::OutputHandler::new();
+    let mut cw = handler.get_clipboard_writer()?;
+    cw.write_all(text.as_bytes())?;
+    cw.finish()?;
+    Ok(())
+}
+
 pub struct TuiOutcome {
     pub paths: Vec<String>,
     pub relative: bool,
@@ -102,6 +111,9 @@ fn tui_main(
                     }
                     AppMode::GitStatus => {
                         app.sync_git_status_diff_scroll(app.visible_height);
+                    }
+                    AppMode::RgFocused | AppMode::RgNavigating => {
+                        app.sync_rg_scroll(app.visible_height);
                     }
                     _ => {
                         app.sync_search_scroll(app.visible_height);

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -123,6 +123,9 @@ fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: u
     let hash_style = Style::default()
         .fg(theme::HASH)
         .add_modifier(Modifier::BOLD);
+    let refs_style = Style::default()
+        .fg(theme::REFS)
+        .add_modifier(Modifier::BOLD);
     let commit_items: Vec<ListItem> = app
         .git_commits
         .iter()
@@ -141,6 +144,10 @@ fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: u
             if is_cursor {
                 h_style = h_style.bg(theme::CURSOR_BG);
             }
+            let mut r_style = refs_style;
+            if is_cursor {
+                r_style = r_style.bg(theme::CURSOR_BG);
+            }
             let marker_style = Style::default()
                 .fg(theme::SELECTED)
                 .add_modifier(Modifier::BOLD);
@@ -156,6 +163,9 @@ fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: u
                     let after = commit.display[pos + commit.hash.len()..].to_string();
                     spans.push(Span::styled(before, fg_style));
                     spans.push(Span::styled(commit.hash.clone(), h_style));
+                    if !commit.refs.is_empty() {
+                        spans.push(Span::styled(format!(" ({})", commit.refs), r_style));
+                    }
                     spans.push(Span::styled(after, fg_style));
                 } else {
                     spans.push(Span::styled(commit.display.clone(), fg_style));

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -61,6 +61,8 @@ pub fn draw(
         render_git_tree(f, app, chunks[1], inner_list_height as usize);
     } else if app.mode == AppMode::GitStatus {
         render_git_status(f, app, chunks[1], inner_list_height as usize);
+    } else if app.mode == AppMode::RgFocused || app.mode == AppMode::RgNavigating {
+        render_rg(f, app, chunks[1], inner_list_height as usize);
     } else {
         render_file_list(f, app, chunks[1], inner_list_height as usize);
     }
@@ -177,7 +179,23 @@ fn render_branch_switch_overlay(f: &mut Frame, area: Rect, branch: &str) {
 
 fn render_path_bar(f: &mut Frame, app: &AppState, area: Rect) {
     let (path, title_str, path_style) =
-        if app.mode == AppMode::SearchFocused || app.mode == AppMode::SearchNavigating {
+        if app.mode == AppMode::RgFocused || app.mode == AppMode::RgNavigating {
+            let rg_display = format!("rg: {}", app.rg_query);
+            let title = if app.mode == AppMode::RgFocused {
+                "Enter pattern, Esc to leave rg".to_string()
+            } else {
+                "y copy result   space select   c copy files   Esc to leave".to_string()
+            };
+            let style = if app.mode == AppMode::RgFocused {
+                Style::default()
+                    .fg(theme::MATCH)
+                    .bg(theme::CURSOR_BG)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            (rg_display, title, style)
+        } else if app.mode == AppMode::SearchFocused || app.mode == AppMode::SearchNavigating {
             let search_display = format!("Search: {}", app.search_query);
             let title = if app.mode == AppMode::SearchFocused {
                 "Enter to search, Esc to leave search".to_string()
@@ -238,6 +256,15 @@ fn render_path_bar(f: &mut Frame, app: &AppState, area: Rect) {
             .x
             .saturating_add(prefix_len)
             .saturating_add(app.search_query.chars().count() as u16)
+            .min(inner.x + inner.width.saturating_sub(1));
+        f.set_cursor_position(Position::new(cursor_x, inner.y));
+    } else if app.mode == AppMode::RgFocused {
+        // "rg: " prefix is 4 chars.
+        let prefix_len = 4u16;
+        let cursor_x = inner
+            .x
+            .saturating_add(prefix_len)
+            .saturating_add(app.rg_query.chars().count() as u16)
             .min(inner.x + inner.width.saturating_sub(1));
         f.set_cursor_position(Position::new(cursor_x, inner.y));
     }
@@ -687,6 +714,126 @@ fn build_git_status_line(app: &AppState, item: &GitStatusItem) -> Line<'static> 
     ])
 }
 
+fn render_rg(f: &mut Frame, app: &mut AppState, area: Rect, list_height: usize) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(area);
+
+    // ── Left panel: file tree (shows current selection state) ──
+    let open = app.tree_state.opened().clone();
+    let visible_dirs = collect_visible_dirs(&app.root_dir, &app.dir_cache, &open);
+    let fully_selected_dirs: HashSet<PathBuf> = visible_dirs
+        .into_iter()
+        .filter(|d| app.dir_fully_selected(d))
+        .collect();
+
+    let items = build_styled_tree_items(
+        &app.root_dir,
+        &app.dir_cache,
+        &open,
+        &app.selected,
+        &fully_selected_dirs,
+    );
+
+    let Ok(tree_widget) = Tree::new(&items) else {
+        f.render_widget(panel("Files", false), chunks[0]);
+        return;
+    };
+    let tree_widget = tree_widget
+        .block(panel("Files", false))
+        .highlight_style(
+            Style::default()
+                .bg(theme::CURSOR_BG)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▎ ");
+    f.render_stateful_widget(tree_widget, chunks[0], &mut app.tree_state);
+
+    // ── Right panel: rg results ──
+    let match_style = Style::default()
+        .fg(theme::MATCH)
+        .add_modifier(Modifier::BOLD);
+
+    let items: Vec<ListItem> = app
+        .rg_results
+        .iter()
+        .enumerate()
+        .skip(app.rg_scroll_offset)
+        .take(list_height)
+        .map(|(i, result)| {
+            let is_cursor = i == app.rg_cursor;
+            let is_selected = app.selected.contains(&result.path);
+
+            let marker = if is_selected { "✓ " } else { "  " };
+            let path_style = Style::default().fg(theme::DIR);
+            let line_num_style = Style::default().fg(theme::HASH);
+            let content_style = Style::default().fg(theme::FG);
+            let muted_style = Style::default().fg(theme::MUTED);
+
+            let mut spans: Vec<Span<'static>> = Vec::new();
+            spans.push(Span::styled(
+                marker,
+                Style::default()
+                    .fg(theme::SELECTED)
+                    .add_modifier(Modifier::BOLD),
+            ));
+
+            let path_str = result.path.display().to_string();
+            let display_path = if path_str.len() > 40 {
+                format!("...{}", &path_str[path_str.len().saturating_sub(37)..])
+            } else {
+                path_str
+            };
+            spans.push(Span::styled(display_path, path_style));
+            spans.push(Span::styled(":", muted_style));
+            spans.push(Span::styled(result.line_number.to_string(), line_num_style));
+            spans.push(Span::styled(":", muted_style));
+
+            let content_line = highlight_matches(
+                &result.line_content,
+                &result.match_indices,
+                content_style,
+                match_style,
+            );
+            spans.extend(content_line.spans);
+
+            let cursor_style = if is_cursor {
+                Style::default()
+                    .bg(theme::CURSOR_BG)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+
+            ListItem::new(Line::from(spans)).style(cursor_style)
+        })
+        .collect();
+
+    let title = if app.rg_results.is_empty() && !app.rg_query.is_empty() {
+        "rg Results (no matches)".to_string()
+    } else {
+        format!("rg Results ({})", app.rg_results.len())
+    };
+    let list = List::new(items).block(panel(&title, app.mode == AppMode::RgNavigating));
+    f.render_widget(list, chunks[1]);
+
+    if !app.rg_results.is_empty() {
+        let mut sb_state =
+            ScrollbarState::new(app.rg_results.len()).position(app.rg_cursor);
+        f.render_stateful_widget(
+            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(None)
+                .end_symbol(None),
+            chunks[1].inner(Margin {
+                vertical: 1,
+                horizontal: 0,
+            }),
+            &mut sb_state,
+        );
+    }
+}
+
 fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize, loc_count: u64, mode: AppMode, aider: bool) {
     let hint_str = match mode {
         AppMode::GitStatus => {
@@ -694,6 +841,9 @@ fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize
         }
         AppMode::GitTree => {
             "space select   d diff   c copy   m aider   ? help   q quit "
+        }
+        AppMode::RgFocused | AppMode::RgNavigating => {
+            "' edit   y copy result   space select   c copy files   m aider   ? help   q quit "
         }
         _ => "space select   c copy   m aider   ? help   q quit ",
     };
@@ -802,6 +952,7 @@ fn build_help_lines() -> Vec<Line<'static>> {
         ("Enter", "Pop stash / Switch branch"),
         ("d", "Toggle diff (Git mode)"),
         ("/ or Ctrl-f", "Search files"),
+        ("'", "rg search file contents"),
         ("?", "Toggle help"),
         ("c", "Confirm selection"),
         ("m", "Toggle aider patch"),

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -65,7 +65,7 @@ pub fn draw(
         render_file_list(f, app, chunks[1], inner_list_height as usize);
     }
     let is_git_mode = app.mode == AppMode::GitTree || app.mode == AppMode::GitStatus;
-    render_status_bar(f, chunks[2], message, file_count, loc_count, app.mode);
+    render_status_bar(f, chunks[2], message, file_count, loc_count, app.mode, app.aider);
     if app.show_help {
         render_help_overlay(f, f.area());
     }
@@ -506,15 +506,15 @@ fn build_git_status_line(app: &AppState, item: &GitStatusItem) -> Line<'static> 
     ])
 }
 
-fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize, loc_count: u64, mode: AppMode) {
+fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize, loc_count: u64, mode: AppMode, aider: bool) {
     let hint_str = match mode {
         AppMode::GitStatus => {
-            "space select   s stage   Tab switch   c copy   ? help   q quit "
+            "space select   s stage   Tab switch   c copy   m aider   ? help   q quit "
         }
         AppMode::GitTree => {
-            "space select   d diff   c copy   ? help   q quit "
+            "space select   d diff   c copy   m aider   ? help   q quit "
         }
-        _ => "space select   c copy   ? help   q quit ",
+        _ => "space select   c copy   m aider   ? help   q quit ",
     };
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
@@ -524,13 +524,20 @@ fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize
         ])
         .split(area);
     if message.is_empty() {
-        let left = Line::from(vec![Span::styled(
+        let mut spans = vec![Span::styled(
             format!(
                 " {file_count} file{} selected | {loc_count} LOC",
                 if file_count == 1 { "" } else { "s" }
             ),
             Style::default().fg(theme::SELECTED),
-        )]);
+        )];
+        if aider {
+            spans.push(Span::styled(
+                " (aider patch)",
+                Style::default().fg(theme::MATCH).add_modifier(Modifier::BOLD),
+            ));
+        }
+        let left = Line::from(spans);
         f.render_widget(Paragraph::new(left), chunks[0]);
     } else {
         let error = Line::from(vec![Span::styled(
@@ -614,6 +621,7 @@ fn build_help_lines() -> Vec<Line<'static>> {
         ("/ or Ctrl-f", "Search files"),
         ("?", "Toggle help"),
         ("c", "Confirm selection"),
+        ("m", "Toggle aider patch"),
         ("p", "Restore last selection"),
         ("q/Ctrl-c", "Quit"),
         ("r", "Toggle relative path"),

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -65,7 +65,7 @@ pub fn draw(
         render_file_list(f, app, chunks[1], inner_list_height as usize);
     }
     let is_git_mode = app.mode == AppMode::GitTree || app.mode == AppMode::GitStatus;
-    render_status_bar(f, chunks[2], message, file_count, loc_count, is_git_mode);
+    render_status_bar(f, chunks[2], message, file_count, loc_count, app.mode);
     if app.show_help {
         render_help_overlay(f, f.area());
     }
@@ -74,7 +74,7 @@ pub fn draw(
 
 fn render_path_bar(f: &mut Frame, app: &AppState, area: Rect) {
     let (path, title_str, path_style) =
-        if app.mode != AppMode::Normal && app.mode != AppMode::GitTree {
+        if app.mode == AppMode::SearchFocused || app.mode == AppMode::SearchNavigating {
             let search_display = format!("Search: {}", app.search_query);
             let title = if app.mode == AppMode::SearchFocused {
                 "Enter to search, Esc to leave search".to_string()
@@ -102,17 +102,25 @@ fn render_path_bar(f: &mut Frame, app: &AppState, area: Rect) {
             } else {
                 app.root_dir.display().to_string()
             };
-            let mut title_str = "Current Directory".to_string();
-            if app.no_path {
-                title_str.push_str(" [n: no path]");
-            } else if app.relative {
-                title_str.push_str(" [r: relative]");
-            }
+            let title_str = if app.mode == AppMode::GitStatus {
+                "Git Status".to_string()
+            } else {
+                let mut t = "Current Directory".to_string();
+                if app.no_path {
+                    t.push_str(" [n: no path]");
+                } else if app.relative {
+                    t.push_str(" [r: relative]");
+                }
+                t
+            };
             (path, title_str, Style::default())
         };
 
     let path_widget = Paragraph::new(path)
-        .block(panel(&title_str, app.mode != AppMode::Normal))
+        .block(panel(
+            &title_str,
+            app.mode != AppMode::Normal && app.mode != AppMode::GitStatus,
+        ))
         .style(path_style)
         .wrap(Wrap { trim: true });
     f.render_widget(path_widget, area);
@@ -379,6 +387,15 @@ fn render_file_list(f: &mut Frame, app: &mut AppState, area: Rect, list_height: 
 }
 
 fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height: usize) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(area);
+
+    let left_area = chunks[0];
+    let right_area = chunks[1];
+
+    // ── Left panel: status list ──
     let staged: Vec<(usize, &GitStatusItem)> = app.git_status_items.iter().enumerate().filter(|(_, i)| i.section == GitStatusSection::Staged).collect();
     let unstaged: Vec<(usize, &GitStatusItem)> = app.git_status_items.iter().enumerate().filter(|(_, i)| i.section == GitStatusSection::Unstaged).collect();
     let untracked: Vec<(usize, &GitStatusItem)> = app.git_status_items.iter().enumerate().filter(|(_, i)| i.section == GitStatusSection::Untracked).collect();
@@ -443,8 +460,32 @@ fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height:
         .map(|(_, item)| item)
         .collect();
 
-    let list = List::new(items).block(panel("Git Status", true));
-    f.render_widget(list, area);
+    let list = List::new(items).block(panel("Git Status", !app.git_status_diff_focused));
+    f.render_widget(list, left_area);
+
+    // ── Right panel: diff ──
+    app.sync_git_status_diff_scroll(list_height);
+    let diff_title = app
+        .git_status_items
+        .get(app.git_status_cursor)
+        .map(|i| i.path.clone())
+        .unwrap_or_else(|| "No changes".to_string());
+    let diff_block = panel(&format!("Diff: {diff_title}"), app.git_status_diff_focused);
+    let diff_inner_width = diff_block.inner(right_area).width;
+    let cursor_line = if app.git_status_diff_focused {
+        Some(app.git_status_diff_cursor)
+    } else {
+        None
+    };
+    let diff_widget = Paragraph::new(build_diff_lines(
+        &app.git_status_diff_content,
+        cursor_line,
+        diff_inner_width,
+    ))
+    .block(diff_block)
+    .scroll((app.git_status_diff_scroll_offset as u16, 0))
+    .wrap(Wrap { trim: false });
+    f.render_widget(diff_widget, right_area);
 }
 
 fn build_git_status_line(app: &AppState, item: &GitStatusItem) -> Line<'static> {
@@ -452,24 +493,28 @@ fn build_git_status_line(app: &AppState, item: &GitStatusItem) -> Line<'static> 
     let is_selected = app.selected.contains(&abs_path);
     let marker = if is_selected { "✓ " } else { "  " };
 
-    let section_str = match item.section {
-        GitStatusSection::Staged => "M ",
-        GitStatusSection::Unstaged => "M ",
-        GitStatusSection::Untracked => "? ",
+    let (section_str, section_color) = match item.section {
+        GitStatusSection::Staged => ("M ", Color::Green),
+        GitStatusSection::Unstaged => ("M ", Color::Yellow),
+        GitStatusSection::Untracked => ("? ", Color::Red),
     };
 
     Line::from(vec![
         Span::styled(marker, Style::default().fg(theme::SELECTED).add_modifier(Modifier::BOLD)),
-        Span::styled(section_str, Style::default().fg(theme::MUTED)),
+        Span::styled(section_str, Style::default().fg(section_color)),
         Span::styled(item.path.clone(), Style::default().fg(theme::FG)),
     ])
 }
 
-fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize, loc_count: u64, is_git_mode: bool) {
-    let hint_str = if is_git_mode {
-        "space select   s stage   d toggle diff   c copy   ? help   q quit "
-    } else {
-        "space select   c copy   ? help   q quit "
+fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize, loc_count: u64, mode: AppMode) {
+    let hint_str = match mode {
+        AppMode::GitStatus => {
+            "space select   s stage   Tab switch   c copy   ? help   q quit "
+        }
+        AppMode::GitTree => {
+            "space select   d diff   c copy   ? help   q quit "
+        }
+        _ => "space select   c copy   ? help   q quit ",
     };
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
@@ -561,8 +606,9 @@ fn build_help_lines() -> Vec<Line<'static>> {
         ("Enter", "Toggle expand"),
         ("Backspace", "Parent dir"),
         ("Space", "Select/Unselect"),
-        ("1", "Toggle git status"),
-        ("2/Tab", "Toggle git tree"),
+        ("1", "Git status mode"),
+        ("2", "Git tree mode"),
+        ("Tab", "Switch panel / exit git"),
         ("s", "Stage/Unstage (Git Status mode)"),
         ("d", "Toggle diff (Git mode)"),
         ("/ or Ctrl-f", "Search files"),

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -807,11 +807,16 @@ fn render_rg(f: &mut Frame, app: &mut AppState, area: Rect, list_height: usize) 
             match_files.push(result.path.as_path());
         }
     }
-    let current_path = app.rg_results.get(app.rg_cursor).map(|r| r.path.as_path());
-    let current_idx = current_path
-        .and_then(|p| match_files.iter().position(|x| *x == p))
-        .unwrap_or(0);
     let list_len = match_files.len();
+    // Files panel reflects rg_file_cursor only — it's fully decoupled from
+    // rg_cursor (the right/match panel). Browsing files never moves the
+    // match panel, and it stays put until focus tabs into it.
+    let current_idx = if list_len == 0 {
+        0
+    } else {
+        app.rg_file_cursor.min(list_len - 1)
+    };
+    let current_path = match_files.get(current_idx).copied();
     let files_scroll_offset = if list_len <= list_height {
         0
     } else if current_idx >= list_height {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -69,7 +69,61 @@ pub fn draw(
     if app.show_help {
         render_help_overlay(f, f.area());
     }
+    if let Some(stash_ref) = app.pending_stash_pop.clone() {
+        let stash_message = app
+            .git_stash_items
+            .iter()
+            .find(|s| s.stash_ref == stash_ref)
+            .map(|s| s.message.clone())
+            .unwrap_or_default();
+        render_confirm_overlay(f, f.area(), &stash_ref, &stash_message);
+    }
     inner_list_height
+}
+
+/// Small centered confirmation modal (e.g. "pop this stash?").
+fn render_confirm_overlay(f: &mut Frame, area: Rect, stash_ref: &str, stash_message: &str) {
+    let modal = centered_rect(46, 24, area);
+    f.render_widget(Clear, modal);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD))
+        .padding(Padding::horizontal(1))
+        .title(Span::styled(
+            " Confirm Stash Pop ",
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(modal);
+    f.render_widget(block, modal);
+
+    let lines = vec![
+        Line::from(Span::styled(
+            format!("Pop {stash_ref}?"),
+            Style::default().fg(theme::FG).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            stash_message.to_string(),
+            Style::default().fg(theme::MUTED),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "y",
+                Style::default()
+                    .fg(theme::SELECTED)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" confirm    ", Style::default().fg(theme::MUTED)),
+            Span::styled(
+                "n / Esc",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" cancel", Style::default().fg(theme::MUTED)),
+        ]),
+    ];
+    f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
 }
 
 fn render_path_bar(f: &mut Frame, app: &AppState, area: Rect) {
@@ -479,7 +533,10 @@ fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height:
         .map(|(_, item)| item)
         .collect();
 
-    let list = List::new(items).block(panel("Git Status", !app.git_status_diff_focused));
+    let list = List::new(items).block(panel(
+        if app.pending_stash_pop.is_some() { "Git Status — confirm pop" } else { "Git Status" },
+        !app.git_status_diff_focused,
+    ));
     f.render_widget(list, left_area);
 
     // ── Right panel: diff ──

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -78,6 +78,9 @@ pub fn draw(
             .unwrap_or_default();
         render_confirm_overlay(f, f.area(), &stash_ref, &stash_message);
     }
+    if let Some(branch) = app.pending_branch_switch.clone() {
+        render_branch_switch_overlay(f, f.area(), &branch);
+    }
     inner_list_height
 }
 
@@ -105,6 +108,52 @@ fn render_confirm_overlay(f: &mut Frame, area: Rect, stash_ref: &str, stash_mess
         )),
         Line::from(Span::styled(
             stash_message.to_string(),
+            Style::default().fg(theme::MUTED),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "y",
+                Style::default()
+                    .fg(theme::SELECTED)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" confirm    ", Style::default().fg(theme::MUTED)),
+            Span::styled(
+                "n / Esc",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" cancel", Style::default().fg(theme::MUTED)),
+        ]),
+    ];
+    f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
+}
+
+/// Centered confirmation modal for branch switching.
+fn render_branch_switch_overlay(f: &mut Frame, area: Rect, branch: &str) {
+    let modal = centered_rect(46, 24, area);
+    f.render_widget(Clear, modal);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme::BORDER_FOCUS).add_modifier(Modifier::BOLD))
+        .padding(Padding::horizontal(1))
+        .title(Span::styled(
+            " Confirm Branch Switch ",
+            Style::default().fg(theme::BORDER_FOCUS).add_modifier(Modifier::BOLD),
+        ));
+    let inner = block.inner(modal);
+    f.render_widget(block, modal);
+
+    let lines = vec![
+        Line::from(Span::styled(
+            format!("Switch to branch '{branch}'?"),
+            Style::default().fg(theme::FG).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Uncommitted changes may be carried over or conflict.",
             Style::default().fg(theme::MUTED),
         )),
         Line::from(""),
@@ -530,6 +579,30 @@ fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height:
         }
     }
 
+    push_header(&mut visual_items, "Branches", app.git_branch_items.len());
+    if app.git_branch_items.is_empty() {
+        visual_items.push((None, ListItem::new(Line::from(Span::styled("   (none)", Style::default().fg(theme::MUTED))))));
+    } else {
+        for (i, branch) in app.git_branch_items.iter().enumerate() {
+            let idx = items_len + app.git_stash_items.len() + i;
+            let is_cursor = idx == app.git_status_cursor;
+            let marker = if branch.is_current { "* " } else { "  " };
+            let name_style = if branch.is_current {
+                Style::default().fg(theme::SELECTED).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme::FG)
+            };
+            let line = Line::from(vec![
+                Span::styled(
+                    marker.to_string(),
+                    Style::default().fg(theme::SELECTED).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(branch.name.clone(), name_style),
+            ]);
+            visual_items.push((Some(idx), ListItem::new(line).style(if is_cursor { Style::default().bg(theme::CURSOR_BG) } else { Style::default() })));
+        }
+    }
+
     let selected_visual = visual_items.iter().position(|(idx, _)| *idx == Some(app.git_status_cursor)).unwrap_or(0);
 
     let scroll_offset = if selected_visual < app.git_status_scroll_offset {
@@ -548,7 +621,9 @@ fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height:
         .collect();
 
     let list = List::new(items).block(panel(
-        if app.pending_stash_pop.is_some() { "Git Status — confirm pop" } else { "Git Status" },
+        if app.pending_stash_pop.is_some() { "Git Status — confirm pop" }
+        else if app.pending_branch_switch.is_some() { "Git Status — confirm switch" }
+        else { "Git Status" },
         !app.git_status_diff_focused,
     ));
     f.render_widget(list, left_area);
@@ -561,10 +636,20 @@ fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height:
             .map(|i| i.path.clone())
             .unwrap_or_else(|| "No changes".to_string())
     } else {
-        app.git_stash_items
-            .get(app.git_status_cursor - items_len)
-            .map(|s| format!("{} {}", s.stash_ref, s.message))
-            .unwrap_or_else(|| "No stash".to_string())
+        let after_items_idx = app.git_status_cursor - items_len;
+        let stash_len = app.git_stash_items.len();
+        if after_items_idx < stash_len {
+            app.git_stash_items
+                .get(after_items_idx)
+                .map(|s| format!("{} {}", s.stash_ref, s.message))
+                .unwrap_or_else(|| "No stash".to_string())
+        } else {
+            let branch_idx = after_items_idx - stash_len;
+            app.git_branch_items
+                .get(branch_idx)
+                .map(|b| format!("branch: {}", b.name))
+                .unwrap_or_else(|| "No branch".to_string())
+        }
     };
     let diff_block = panel(&format!("Diff: {diff_title}"), app.git_status_diff_focused);
     let diff_inner_width = diff_block.inner(right_area).width;
@@ -714,7 +799,7 @@ fn build_help_lines() -> Vec<Line<'static>> {
         ("Tab", "Switch panel / exit git"),
         ("s", "Stage/Unstage (Git Status mode)"),
         ("z", "Stash changes (Git Status mode)"),
-        ("Enter", "Pop stash (on stash item)"),
+        ("Enter", "Pop stash / Switch branch"),
         ("d", "Toggle diff (Git mode)"),
         ("/ or Ctrl-f", "Search files"),
         ("?", "Toggle help"),

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -17,7 +17,7 @@ use std::{
 use tui_tree_widget::{Tree, TreeItem};
 
 use super::theme;
-use crate::tui::app::{AppMode, AppState, DirItem};
+use crate::tui::app::{AppMode, AppState, DirItem, GitStatusItem, GitStatusSection};
 
 fn panel(title: &str, focused: bool) -> Block<'static> {
     Block::default()
@@ -59,10 +59,13 @@ pub fn draw(
     render_path_bar(f, app, chunks[0]);
     if app.mode == AppMode::GitTree {
         render_git_tree(f, app, chunks[1], inner_list_height as usize);
+    } else if app.mode == AppMode::GitStatus {
+        render_git_status(f, app, chunks[1], inner_list_height as usize);
     } else {
         render_file_list(f, app, chunks[1], inner_list_height as usize);
     }
-    render_status_bar(f, chunks[2], message, file_count, loc_count, app.mode == AppMode::GitTree);
+    let is_git_mode = app.mode == AppMode::GitTree || app.mode == AppMode::GitStatus;
+    render_status_bar(f, chunks[2], message, file_count, loc_count, is_git_mode);
     if app.show_help {
         render_help_overlay(f, f.area());
     }
@@ -375,9 +378,96 @@ fn render_file_list(f: &mut Frame, app: &mut AppState, area: Rect, list_height: 
     f.render_stateful_widget(tree_widget, area, &mut app.tree_state);
 }
 
+fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height: usize) {
+    let staged: Vec<(usize, &GitStatusItem)> = app.git_status_items.iter().enumerate().filter(|(_, i)| i.section == GitStatusSection::Staged).collect();
+    let unstaged: Vec<(usize, &GitStatusItem)> = app.git_status_items.iter().enumerate().filter(|(_, i)| i.section == GitStatusSection::Unstaged).collect();
+    let untracked: Vec<(usize, &GitStatusItem)> = app.git_status_items.iter().enumerate().filter(|(_, i)| i.section == GitStatusSection::Untracked).collect();
+
+    let header_style = Style::default().fg(theme::MUTED).add_modifier(Modifier::BOLD);
+    let divider_style = Style::default().fg(theme::BORDER);
+
+    let mut visual_items: Vec<(Option<usize>, ListItem)> = Vec::new();
+
+    let push_header = |v: &mut Vec<(Option<usize>, ListItem)>, title: &str, count: usize| {
+        v.push((None, ListItem::new(Line::from(Span::styled(format!(" {title} ({count})"), header_style)))));
+        v.push((None, ListItem::new(Line::from(Span::styled(" ────────────────────────────────────────", divider_style)))));
+    };
+
+    push_header(&mut visual_items, "Staged Changes", staged.len());
+    if staged.is_empty() {
+        visual_items.push((None, ListItem::new(Line::from(Span::styled("   (none)", Style::default().fg(theme::MUTED))))));
+    } else {
+        for (idx, item) in &staged {
+            let is_cursor = *idx == app.git_status_cursor;
+            let line = build_git_status_line(app, item);
+            visual_items.push((Some(*idx), ListItem::new(line).style(if is_cursor { Style::default().bg(theme::CURSOR_BG) } else { Style::default() })));
+        }
+    }
+
+    push_header(&mut visual_items, "Unstaged Changes", unstaged.len());
+    if unstaged.is_empty() {
+        visual_items.push((None, ListItem::new(Line::from(Span::styled("   (none)", Style::default().fg(theme::MUTED))))));
+    } else {
+        for (idx, item) in &unstaged {
+            let is_cursor = *idx == app.git_status_cursor;
+            let line = build_git_status_line(app, item);
+            visual_items.push((Some(*idx), ListItem::new(line).style(if is_cursor { Style::default().bg(theme::CURSOR_BG) } else { Style::default() })));
+        }
+    }
+
+    push_header(&mut visual_items, "Untracked Files", untracked.len());
+    if untracked.is_empty() {
+        visual_items.push((None, ListItem::new(Line::from(Span::styled("   (none)", Style::default().fg(theme::MUTED))))));
+    } else {
+        for (idx, item) in &untracked {
+            let is_cursor = *idx == app.git_status_cursor;
+            let line = build_git_status_line(app, item);
+            visual_items.push((Some(*idx), ListItem::new(line).style(if is_cursor { Style::default().bg(theme::CURSOR_BG) } else { Style::default() })));
+        }
+    }
+
+    let selected_visual = visual_items.iter().position(|(idx, _)| *idx == Some(app.git_status_cursor)).unwrap_or(0);
+
+    let scroll_offset = if selected_visual < app.git_status_scroll_offset {
+        selected_visual
+    } else if selected_visual >= app.git_status_scroll_offset + list_height {
+        selected_visual + 1 - list_height
+    } else {
+        app.git_status_scroll_offset
+    };
+    app.git_status_scroll_offset = scroll_offset;
+
+    let items: Vec<ListItem> = visual_items.into_iter()
+        .skip(scroll_offset)
+        .take(list_height)
+        .map(|(_, item)| item)
+        .collect();
+
+    let list = List::new(items).block(panel("Git Status", true));
+    f.render_widget(list, area);
+}
+
+fn build_git_status_line(app: &AppState, item: &GitStatusItem) -> Line<'static> {
+    let abs_path = app.git_file_abs_path(&item.path);
+    let is_selected = app.selected.contains(&abs_path);
+    let marker = if is_selected { "✓ " } else { "  " };
+
+    let section_str = match item.section {
+        GitStatusSection::Staged => "M ",
+        GitStatusSection::Unstaged => "M ",
+        GitStatusSection::Untracked => "? ",
+    };
+
+    Line::from(vec![
+        Span::styled(marker, Style::default().fg(theme::SELECTED).add_modifier(Modifier::BOLD)),
+        Span::styled(section_str, Style::default().fg(theme::MUTED)),
+        Span::styled(item.path.clone(), Style::default().fg(theme::FG)),
+    ])
+}
+
 fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize, loc_count: u64, is_git_mode: bool) {
     let hint_str = if is_git_mode {
-        "space select   d toggle diff   c copy   ? help   q quit "
+        "space select   s stage   d toggle diff   c copy   ? help   q quit "
     } else {
         "space select   c copy   ? help   q quit "
     };
@@ -471,9 +561,11 @@ fn build_help_lines() -> Vec<Line<'static>> {
         ("Enter", "Toggle expand"),
         ("Backspace", "Parent dir"),
         ("Space", "Select/Unselect"),
+        ("1", "Toggle git status"),
+        ("2/Tab", "Toggle git tree"),
+        ("s", "Stage/Unstage (Git Status mode)"),
         ("d", "Toggle diff (Git mode)"),
         ("/ or Ctrl-f", "Search files"),
-        ("Tab", "Toggle git tree"),
         ("?", "Toggle help"),
         ("c", "Confirm selection"),
         ("p", "Restore last selection"),

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,6 +1,6 @@
 use pathdiff::diff_paths;
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Margin, Rect},
+    layout::{Constraint, Direction, Layout, Margin, Position, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
@@ -170,14 +170,28 @@ fn render_path_bar(f: &mut Frame, app: &AppState, area: Rect) {
             (path, title_str, Style::default())
         };
 
+    let block = panel(
+        &title_str,
+        app.mode != AppMode::Normal && app.mode != AppMode::GitStatus,
+    );
+    let inner = block.inner(area);
     let path_widget = Paragraph::new(path)
-        .block(panel(
-            &title_str,
-            app.mode != AppMode::Normal && app.mode != AppMode::GitStatus,
-        ))
+        .block(block)
         .style(path_style)
         .wrap(Wrap { trim: true });
     f.render_widget(path_widget, area);
+    if app.mode == AppMode::SearchFocused {
+        // Position the native cursor right after the typed query text.
+        // "Search: " prefix is 8 chars; clamp so a very long query can't
+        // push the cursor outside the panel.
+        let prefix_len = 8u16;
+        let cursor_x = inner
+            .x
+            .saturating_add(prefix_len)
+            .saturating_add(app.search_query.chars().count() as u16)
+            .min(inner.x + inner.width.saturating_sub(1));
+        f.set_cursor_position(Position::new(cursor_x, inner.y));
+    }
 }
 
 fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: usize) {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,3 +1,5 @@
+use super::theme;
+use crate::tui::app::{AppMode, AppState, DirItem, GitStatusItem, GitStatusSection};
 use pathdiff::diff_paths;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Margin, Position, Rect},
@@ -15,10 +17,6 @@ use std::{
     path::PathBuf,
 };
 use tui_tree_widget::{Tree, TreeItem};
-
-use super::theme;
-use crate::tui::app::{AppMode, AppState, DirItem, GitStatusItem, GitStatusSection};
-
 fn panel(title: &str, focused: bool) -> Block<'static> {
     Block::default()
         .borders(Borders::ALL)
@@ -36,7 +34,6 @@ fn panel(title: &str, focused: bool) -> Block<'static> {
                 .add_modifier(Modifier::BOLD),
         ))
 }
-
 /// Render the full TUI frame and return the inner file-list height in rows.
 pub fn draw(
     f: &mut Frame,
@@ -67,7 +64,9 @@ pub fn draw(
         render_file_list(f, app, chunks[1], inner_list_height as usize);
     }
     let is_git_mode = app.mode == AppMode::GitTree || app.mode == AppMode::GitStatus;
-    render_status_bar(f, chunks[2], message, file_count, loc_count, app.mode, app.aider);
+    render_status_bar(
+        f, chunks[2], message, file_count, loc_count, app.mode, app.aider,
+    );
     if app.show_help {
         render_help_overlay(f, f.area());
     }
@@ -85,12 +84,10 @@ pub fn draw(
     }
     inner_list_height
 }
-
 /// Small centered confirmation modal (e.g. "pop this stash?").
 fn render_confirm_overlay(f: &mut Frame, area: Rect, stash_ref: &str, stash_message: &str) {
     let modal = centered_rect(46, 24, area);
     f.render_widget(Clear, modal);
-
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
@@ -102,7 +99,6 @@ fn render_confirm_overlay(f: &mut Frame, area: Rect, stash_ref: &str, stash_mess
         ));
     let inner = block.inner(modal);
     f.render_widget(block, modal);
-
     let lines = vec![
         Line::from(Span::styled(
             format!("Pop {stash_ref}?"),
@@ -130,24 +126,27 @@ fn render_confirm_overlay(f: &mut Frame, area: Rect, stash_ref: &str, stash_mess
     ];
     f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
 }
-
 /// Centered confirmation modal for branch switching.
 fn render_branch_switch_overlay(f: &mut Frame, area: Rect, branch: &str) {
     let modal = centered_rect(46, 24, area);
     f.render_widget(Clear, modal);
-
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(theme::BORDER_FOCUS).add_modifier(Modifier::BOLD))
+        .border_style(
+            Style::default()
+                .fg(theme::BORDER_FOCUS)
+                .add_modifier(Modifier::BOLD),
+        )
         .padding(Padding::horizontal(1))
         .title(Span::styled(
             " Confirm Branch Switch ",
-            Style::default().fg(theme::BORDER_FOCUS).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme::BORDER_FOCUS)
+                .add_modifier(Modifier::BOLD),
         ));
     let inner = block.inner(modal);
     f.render_widget(block, modal);
-
     let lines = vec![
         Line::from(Span::styled(
             format!("Switch to branch '{branch}'?"),
@@ -176,7 +175,6 @@ fn render_branch_switch_overlay(f: &mut Frame, area: Rect, branch: &str) {
     ];
     f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
 }
-
 fn render_path_bar(f: &mut Frame, app: &AppState, area: Rect) {
     let (path, title_str, path_style) =
         if app.mode == AppMode::RgFocused || app.mode == AppMode::RgNavigating {
@@ -236,7 +234,6 @@ fn render_path_bar(f: &mut Frame, app: &AppState, area: Rect) {
             };
             (path, title_str, Style::default())
         };
-
     let block = panel(
         &title_str,
         app.mode != AppMode::Normal && app.mode != AppMode::GitStatus,
@@ -269,7 +266,6 @@ fn render_path_bar(f: &mut Frame, app: &AppState, area: Rect) {
         f.set_cursor_position(Position::new(cursor_x, inner.y));
     }
 }
-
 fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: usize) {
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
@@ -388,7 +384,6 @@ fn render_git_tree(f: &mut Frame, app: &mut AppState, area: Rect, list_height: u
         f.render_widget(file_list, chunks[1]);
     }
 }
-
 /// Style diff lines: additions green, deletions red, hunk headers highlighted,
 /// file headers (+++/---) muted.
 fn build_diff_lines(content: &str, cursor_line: Option<usize>, width: u16) -> Vec<Line<'static>> {
@@ -423,7 +418,6 @@ fn build_diff_lines(content: &str, cursor_line: Option<usize>, width: u16) -> Ve
         })
         .collect()
 }
-
 fn render_file_list(f: &mut Frame, app: &mut AppState, area: Rect, list_height: usize) {
     if app.mode != AppMode::Normal {
         let match_style = Style::default()
@@ -442,14 +436,12 @@ fn render_file_list(f: &mut Frame, app: &mut AppState, area: Rect, list_height: 
                 }
                 let is_cursor = i == app.search_cursor;
                 let is_selected = app.is_selected(&result.path, result.is_dir);
-
                 let marker = if is_selected { "✓ " } else { "  " };
                 let base_style = if result.is_dir {
                     Style::default().fg(theme::DIR)
                 } else {
                     Style::default().fg(theme::FG)
                 };
-
                 let mut line = highlight_matches(
                     &display_text,
                     &result.match_indices,
@@ -465,7 +457,6 @@ fn render_file_list(f: &mut Frame, app: &mut AppState, area: Rect, list_height: 
                             .add_modifier(Modifier::BOLD),
                     ),
                 );
-
                 let cursor_style = if is_cursor {
                     Style::default()
                         .bg(theme::CURSOR_BG)
@@ -473,14 +464,11 @@ fn render_file_list(f: &mut Frame, app: &mut AppState, area: Rect, list_height: 
                 } else {
                     Style::default()
                 };
-
                 ListItem::new(line).style(cursor_style)
             })
             .collect();
-
         let list = List::new(items).block(panel("Files", app.mode != AppMode::Normal));
         f.render_widget(list, area);
-
         let mut sb_state =
             ScrollbarState::new(app.search_results.len()).position(app.search_cursor);
         f.render_stateful_widget(
@@ -495,7 +483,6 @@ fn render_file_list(f: &mut Frame, app: &mut AppState, area: Rect, list_height: 
         );
         return;
     }
-
     // Normal mode: collapsible tree view.
     // Pre-pass: compute which visible directories are fully selected so we can
     // pass an immutable HashSet into the recursive tree builder (avoids borrow
@@ -506,7 +493,6 @@ fn render_file_list(f: &mut Frame, app: &mut AppState, area: Rect, list_height: 
         .into_iter()
         .filter(|d| app.dir_fully_selected(d))
         .collect();
-
     let items = build_styled_tree_items(
         &app.root_dir,
         &app.dir_cache,
@@ -514,7 +500,6 @@ fn render_file_list(f: &mut Frame, app: &mut AppState, area: Rect, list_height: 
         &app.selected,
         &fully_selected_dirs,
     );
-
     let Ok(tree_widget) = Tree::new(&items) else {
         f.render_widget(panel("Files", true), area);
         return;
@@ -529,68 +514,132 @@ fn render_file_list(f: &mut Frame, app: &mut AppState, area: Rect, list_height: 
         .highlight_symbol("▎ ");
     f.render_stateful_widget(tree_widget, area, &mut app.tree_state);
 }
-
 fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height: usize) {
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
         .split(area);
-
     let left_area = chunks[0];
     let right_area = chunks[1];
-
     // ── Left panel: status list ──
-    let staged: Vec<(usize, &GitStatusItem)> = app.git_status_items.iter().enumerate().filter(|(_, i)| i.section == GitStatusSection::Staged).collect();
-    let unstaged: Vec<(usize, &GitStatusItem)> = app.git_status_items.iter().enumerate().filter(|(_, i)| i.section == GitStatusSection::Unstaged).collect();
-    let untracked: Vec<(usize, &GitStatusItem)> = app.git_status_items.iter().enumerate().filter(|(_, i)| i.section == GitStatusSection::Untracked).collect();
+    let staged: Vec<(usize, &GitStatusItem)> = app
+        .git_status_items
+        .iter()
+        .enumerate()
+        .filter(|(_, i)| i.section == GitStatusSection::Staged)
+        .collect();
+    let unstaged: Vec<(usize, &GitStatusItem)> = app
+        .git_status_items
+        .iter()
+        .enumerate()
+        .filter(|(_, i)| i.section == GitStatusSection::Unstaged)
+        .collect();
+    let untracked: Vec<(usize, &GitStatusItem)> = app
+        .git_status_items
+        .iter()
+        .enumerate()
+        .filter(|(_, i)| i.section == GitStatusSection::Untracked)
+        .collect();
     let items_len = app.git_status_items.len();
-
-    let header_style = Style::default().fg(theme::MUTED).add_modifier(Modifier::BOLD);
+    let header_style = Style::default()
+        .fg(theme::MUTED)
+        .add_modifier(Modifier::BOLD);
     let divider_style = Style::default().fg(theme::BORDER);
-
     let mut visual_items: Vec<(Option<usize>, ListItem)> = Vec::new();
-
     let push_header = |v: &mut Vec<(Option<usize>, ListItem)>, title: &str, count: usize| {
-        v.push((None, ListItem::new(Line::from(Span::styled(format!(" {title} ({count})"), header_style)))));
-        v.push((None, ListItem::new(Line::from(Span::styled(" ────────────────────────────────────────", divider_style)))));
+        v.push((
+            None,
+            ListItem::new(Line::from(Span::styled(
+                format!(" {title} ({count})"),
+                header_style,
+            ))),
+        ));
+        v.push((
+            None,
+            ListItem::new(Line::from(Span::styled(
+                " ────────────────────────────────────────",
+                divider_style,
+            ))),
+        ));
     };
-
     push_header(&mut visual_items, "Staged Changes", staged.len());
     if staged.is_empty() {
-        visual_items.push((None, ListItem::new(Line::from(Span::styled("   (none)", Style::default().fg(theme::MUTED))))));
+        visual_items.push((
+            None,
+            ListItem::new(Line::from(Span::styled(
+                "   (none)",
+                Style::default().fg(theme::MUTED),
+            ))),
+        ));
     } else {
         for (idx, item) in &staged {
             let is_cursor = *idx == app.git_status_cursor;
             let line = build_git_status_line(app, item);
-            visual_items.push((Some(*idx), ListItem::new(line).style(if is_cursor { Style::default().bg(theme::CURSOR_BG) } else { Style::default() })));
+            visual_items.push((
+                Some(*idx),
+                ListItem::new(line).style(if is_cursor {
+                    Style::default().bg(theme::CURSOR_BG)
+                } else {
+                    Style::default()
+                }),
+            ));
         }
     }
-
     push_header(&mut visual_items, "Unstaged Changes", unstaged.len());
     if unstaged.is_empty() {
-        visual_items.push((None, ListItem::new(Line::from(Span::styled("   (none)", Style::default().fg(theme::MUTED))))));
+        visual_items.push((
+            None,
+            ListItem::new(Line::from(Span::styled(
+                "   (none)",
+                Style::default().fg(theme::MUTED),
+            ))),
+        ));
     } else {
         for (idx, item) in &unstaged {
             let is_cursor = *idx == app.git_status_cursor;
             let line = build_git_status_line(app, item);
-            visual_items.push((Some(*idx), ListItem::new(line).style(if is_cursor { Style::default().bg(theme::CURSOR_BG) } else { Style::default() })));
+            visual_items.push((
+                Some(*idx),
+                ListItem::new(line).style(if is_cursor {
+                    Style::default().bg(theme::CURSOR_BG)
+                } else {
+                    Style::default()
+                }),
+            ));
         }
     }
-
     push_header(&mut visual_items, "Untracked Files", untracked.len());
     if untracked.is_empty() {
-        visual_items.push((None, ListItem::new(Line::from(Span::styled("   (none)", Style::default().fg(theme::MUTED))))));
+        visual_items.push((
+            None,
+            ListItem::new(Line::from(Span::styled(
+                "   (none)",
+                Style::default().fg(theme::MUTED),
+            ))),
+        ));
     } else {
         for (idx, item) in &untracked {
             let is_cursor = *idx == app.git_status_cursor;
             let line = build_git_status_line(app, item);
-            visual_items.push((Some(*idx), ListItem::new(line).style(if is_cursor { Style::default().bg(theme::CURSOR_BG) } else { Style::default() })));
+            visual_items.push((
+                Some(*idx),
+                ListItem::new(line).style(if is_cursor {
+                    Style::default().bg(theme::CURSOR_BG)
+                } else {
+                    Style::default()
+                }),
+            ));
         }
     }
-
     push_header(&mut visual_items, "Stash", app.git_stash_items.len());
     if app.git_stash_items.is_empty() {
-        visual_items.push((None, ListItem::new(Line::from(Span::styled("   (none)", Style::default().fg(theme::MUTED))))));
+        visual_items.push((
+            None,
+            ListItem::new(Line::from(Span::styled(
+                "   (none)",
+                Style::default().fg(theme::MUTED),
+            ))),
+        ));
     } else {
         for (i, stash) in app.git_stash_items.iter().enumerate() {
             let idx = items_len + i;
@@ -598,40 +647,66 @@ fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height:
             let line = Line::from(vec![
                 Span::styled(
                     format!("{} ", stash.stash_ref),
-                    Style::default().fg(theme::HASH).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(theme::HASH)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(stash.message.clone(), Style::default().fg(theme::FG)),
             ]);
-            visual_items.push((Some(idx), ListItem::new(line).style(if is_cursor { Style::default().bg(theme::CURSOR_BG) } else { Style::default() })));
+            visual_items.push((
+                Some(idx),
+                ListItem::new(line).style(if is_cursor {
+                    Style::default().bg(theme::CURSOR_BG)
+                } else {
+                    Style::default()
+                }),
+            ));
         }
     }
-
     push_header(&mut visual_items, "Branches", app.git_branch_items.len());
     if app.git_branch_items.is_empty() {
-        visual_items.push((None, ListItem::new(Line::from(Span::styled("   (none)", Style::default().fg(theme::MUTED))))));
+        visual_items.push((
+            None,
+            ListItem::new(Line::from(Span::styled(
+                "   (none)",
+                Style::default().fg(theme::MUTED),
+            ))),
+        ));
     } else {
         for (i, branch) in app.git_branch_items.iter().enumerate() {
             let idx = items_len + app.git_stash_items.len() + i;
             let is_cursor = idx == app.git_status_cursor;
             let marker = if branch.is_current { "* " } else { "  " };
             let name_style = if branch.is_current {
-                Style::default().fg(theme::SELECTED).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(theme::SELECTED)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(theme::FG)
             };
             let line = Line::from(vec![
                 Span::styled(
                     marker.to_string(),
-                    Style::default().fg(theme::SELECTED).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(theme::SELECTED)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(branch.name.clone(), name_style),
             ]);
-            visual_items.push((Some(idx), ListItem::new(line).style(if is_cursor { Style::default().bg(theme::CURSOR_BG) } else { Style::default() })));
+            visual_items.push((
+                Some(idx),
+                ListItem::new(line).style(if is_cursor {
+                    Style::default().bg(theme::CURSOR_BG)
+                } else {
+                    Style::default()
+                }),
+            ));
         }
     }
-
-    let selected_visual = visual_items.iter().position(|(idx, _)| *idx == Some(app.git_status_cursor)).unwrap_or(0);
-
+    let selected_visual = visual_items
+        .iter()
+        .position(|(idx, _)| *idx == Some(app.git_status_cursor))
+        .unwrap_or(0);
     let scroll_offset = if selected_visual < app.git_status_scroll_offset {
         selected_visual
     } else if selected_visual >= app.git_status_scroll_offset + list_height {
@@ -640,21 +715,23 @@ fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height:
         app.git_status_scroll_offset
     };
     app.git_status_scroll_offset = scroll_offset;
-
-    let items: Vec<ListItem> = visual_items.into_iter()
+    let items: Vec<ListItem> = visual_items
+        .into_iter()
         .skip(scroll_offset)
         .take(list_height)
         .map(|(_, item)| item)
         .collect();
-
     let list = List::new(items).block(panel(
-        if app.pending_stash_pop.is_some() { "Git Status — confirm pop" }
-        else if app.pending_branch_switch.is_some() { "Git Status — confirm switch" }
-        else { "Git Status" },
+        if app.pending_stash_pop.is_some() {
+            "Git Status — confirm pop"
+        } else if app.pending_branch_switch.is_some() {
+            "Git Status — confirm switch"
+        } else {
+            "Git Status"
+        },
         !app.git_status_diff_focused,
     ));
     f.render_widget(list, left_area);
-
     // ── Right panel: diff ──
     app.sync_git_status_diff_scroll(list_height);
     let diff_title = if app.git_status_cursor < items_len {
@@ -695,20 +772,22 @@ fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height:
     .wrap(Wrap { trim: false });
     f.render_widget(diff_widget, right_area);
 }
-
 fn build_git_status_line(app: &AppState, item: &GitStatusItem) -> Line<'static> {
     let abs_path = app.git_file_abs_path(&item.path);
     let is_selected = app.selected.contains(&abs_path);
     let marker = if is_selected { "✓ " } else { "  " };
-
     let (section_str, section_color) = match item.section {
         GitStatusSection::Staged => ("M ", Color::Green),
         GitStatusSection::Unstaged => ("M ", Color::Yellow),
         GitStatusSection::Untracked => ("? ", Color::Red),
     };
-
     Line::from(vec![
-        Span::styled(marker, Style::default().fg(theme::SELECTED).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            marker,
+            Style::default()
+                .fg(theme::SELECTED)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled(section_str, Style::default().fg(section_color)),
         Span::styled(item.path.clone(), Style::default().fg(theme::FG)),
     ])
@@ -719,108 +798,157 @@ fn render_rg(f: &mut Frame, app: &mut AppState, area: Rect, list_height: usize) 
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
         .split(area);
-
-    // ── Left panel: file tree (shows current selection state) ──
-    let open = app.tree_state.opened().clone();
-    let visible_dirs = collect_visible_dirs(&app.root_dir, &app.dir_cache, &open);
-    let fully_selected_dirs: HashSet<PathBuf> = visible_dirs
-        .into_iter()
-        .filter(|d| app.dir_fully_selected(d))
-        .collect();
-
-    let items = build_styled_tree_items(
-        &app.root_dir,
-        &app.dir_cache,
-        &open,
-        &app.selected,
-        &fully_selected_dirs,
-    );
-
-    let Ok(tree_widget) = Tree::new(&items) else {
-        f.render_widget(panel("Files", false), chunks[0]);
-        return;
+    // ── Left panel: unique files that matched, derived from rg_results ──
+    // (not the full directory tree — only files rg actually found matches in)
+    let mut seen: HashSet<&std::path::Path> = HashSet::new();
+    let mut match_files: Vec<&std::path::Path> = Vec::new();
+    for result in &app.rg_results {
+        if seen.insert(result.path.as_path()) {
+            match_files.push(result.path.as_path());
+        }
+    }
+    let current_path = app.rg_results.get(app.rg_cursor).map(|r| r.path.as_path());
+    let current_idx = current_path
+        .and_then(|p| match_files.iter().position(|x| *x == p))
+        .unwrap_or(0);
+    let list_len = match_files.len();
+    let files_scroll_offset = if list_len <= list_height {
+        0
+    } else if current_idx >= list_height {
+        (current_idx + 1 - list_height).min(list_len - list_height)
+    } else {
+        0
     };
-    let tree_widget = tree_widget
-        .block(panel("Files", false))
-        .highlight_style(
-            Style::default()
-                .bg(theme::CURSOR_BG)
-                .add_modifier(Modifier::BOLD),
-        )
-        .highlight_symbol("▎ ");
-    f.render_stateful_widget(tree_widget, chunks[0], &mut app.tree_state);
-
-    // ── Right panel: rg results ──
+    let file_items: Vec<ListItem> = match_files
+        .iter()
+        .enumerate()
+        .skip(files_scroll_offset)
+        .take(list_height)
+        .map(|(_, path)| {
+            let is_selected = app.selected.contains(*path);
+            let is_current = current_path == Some(*path);
+            let marker = if is_selected { "✓ " } else { "  " };
+            let path_style = Style::default().fg(theme::DIR);
+            let line = Line::from(vec![
+                Span::styled(
+                    marker,
+                    Style::default()
+                        .fg(theme::SELECTED)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(path.display().to_string(), path_style),
+            ]);
+            let row_style = if is_current {
+                Style::default().bg(theme::CURSOR_BG)
+            } else {
+                Style::default()
+            };
+            ListItem::new(line).style(row_style)
+        })
+        .collect();
+    let files_title = format!("Files ({list_len})");
+    let file_list = List::new(file_items).block(panel(&files_title, app.rg_files_focused));
+    f.render_widget(file_list, chunks[0]);
+    if list_len > list_height {
+        let mut sb_state = ScrollbarState::new(list_len).position(current_idx);
+        f.render_stateful_widget(
+            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(None)
+                .end_symbol(None),
+            chunks[0].inner(Margin {
+                vertical: 1,
+                horizontal: 0,
+            }),
+            &mut sb_state,
+        );
+    }
+    // ── Right panel: rg results, grouped by file (rg --heading style) ──
+    // Consecutive results sharing a path are grouped under one header row
+    // instead of repeating the (often long) path on every match line.
     let match_style = Style::default()
         .fg(theme::MATCH)
         .add_modifier(Modifier::BOLD);
-
-    let items: Vec<ListItem> = app
-        .rg_results
-        .iter()
-        .enumerate()
-        .skip(app.rg_scroll_offset)
-        .take(list_height)
-        .map(|(i, result)| {
-            let is_cursor = i == app.rg_cursor;
-            let is_selected = app.selected.contains(&result.path);
-
-            let marker = if is_selected { "✓ " } else { "  " };
-            let path_style = Style::default().fg(theme::DIR);
-            let line_num_style = Style::default().fg(theme::HASH);
-            let content_style = Style::default().fg(theme::FG);
-            let muted_style = Style::default().fg(theme::MUTED);
-
-            let mut spans: Vec<Span<'static>> = Vec::new();
-            spans.push(Span::styled(
-                marker,
+    let header_style = Style::default().fg(theme::DIR).add_modifier(Modifier::BOLD);
+    let line_num_style = Style::default().fg(theme::HASH);
+    let content_style = Style::default().fg(theme::FG);
+    let muted_style = Style::default().fg(theme::MUTED);
+    let mut visual_items: Vec<(Option<usize>, ListItem)> = Vec::new();
+    let mut last_path: Option<&std::path::Path> = None;
+    for (i, result) in app.rg_results.iter().enumerate() {
+        if last_path != Some(result.path.as_path()) {
+            visual_items.push((
+                None,
+                ListItem::new(Line::from(Span::styled(
+                    result.path.display().to_string(),
+                    header_style,
+                ))),
+            ));
+            last_path = Some(result.path.as_path());
+        }
+        let is_cursor = i == app.rg_cursor;
+        let is_selected = app.selected.contains(&result.path);
+        let marker = if is_selected { "✓ " } else { "  " };
+        let mut spans: Vec<Span<'static>> = vec![
+            Span::styled(
+                format!("  {marker}"),
                 Style::default()
                     .fg(theme::SELECTED)
                     .add_modifier(Modifier::BOLD),
-            ));
-
-            let path_str = result.path.display().to_string();
-            let display_path = if path_str.len() > 40 {
-                format!("...{}", &path_str[path_str.len().saturating_sub(37)..])
-            } else {
-                path_str
-            };
-            spans.push(Span::styled(display_path, path_style));
-            spans.push(Span::styled(":", muted_style));
-            spans.push(Span::styled(result.line_number.to_string(), line_num_style));
-            spans.push(Span::styled(":", muted_style));
-
-            let content_line = highlight_matches(
-                &result.line_content,
-                &result.match_indices,
-                content_style,
-                match_style,
-            );
-            spans.extend(content_line.spans);
-
-            let cursor_style = if is_cursor {
-                Style::default()
-                    .bg(theme::CURSOR_BG)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default()
-            };
-
-            ListItem::new(Line::from(spans)).style(cursor_style)
-        })
+            ),
+            Span::styled(result.line_number.to_string(), line_num_style),
+            Span::styled(":", muted_style),
+        ];
+        let content_line = highlight_matches(
+            &result.line_content,
+            &result.match_indices,
+            content_style,
+            match_style,
+        );
+        spans.extend(content_line.spans);
+        let cursor_style = if is_cursor {
+            Style::default()
+                .bg(theme::CURSOR_BG)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        visual_items.push((
+            Some(i),
+            ListItem::new(Line::from(spans)).style(cursor_style),
+        ));
+    }
+    let visual_len = visual_items.len();
+    let selected_visual = visual_items
+        .iter()
+        .position(|(idx, _)| *idx == Some(app.rg_cursor))
+        .unwrap_or(0);
+    let mut scroll_offset = if selected_visual < app.rg_scroll_offset {
+        selected_visual
+    } else if selected_visual >= app.rg_scroll_offset + list_height {
+        selected_visual + 1 - list_height
+    } else {
+        app.rg_scroll_offset
+    };
+    scroll_offset = scroll_offset.min(visual_len.saturating_sub(list_height));
+    app.rg_scroll_offset = scroll_offset;
+    let items: Vec<ListItem> = visual_items
+        .into_iter()
+        .skip(scroll_offset)
+        .take(list_height)
+        .map(|(_, item)| item)
         .collect();
-
     let title = if app.rg_results.is_empty() && !app.rg_query.is_empty() {
         "rg Results (no matches)".to_string()
     } else {
         format!("rg Results ({})", app.rg_results.len())
     };
-    let list = List::new(items).block(panel(&title, app.mode == AppMode::RgNavigating));
+    let list = List::new(items).block(panel(
+        &title,
+        app.mode == AppMode::RgNavigating && !app.rg_files_focused,
+    ));
     f.render_widget(list, chunks[1]);
-
-    if !app.rg_results.is_empty() {
-        let mut sb_state =
-            ScrollbarState::new(app.rg_results.len()).position(app.rg_cursor);
+    if visual_len > 0 {
+        let mut sb_state = ScrollbarState::new(visual_len).position(selected_visual);
         f.render_stateful_widget(
             Scrollbar::new(ScrollbarOrientation::VerticalRight)
                 .begin_symbol(None)
@@ -833,17 +961,22 @@ fn render_rg(f: &mut Frame, app: &mut AppState, area: Rect, list_height: usize) 
         );
     }
 }
-
-fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize, loc_count: u64, mode: AppMode, aider: bool) {
+fn render_status_bar(
+    f: &mut Frame,
+    area: Rect,
+    message: &str,
+    file_count: usize,
+    loc_count: u64,
+    mode: AppMode,
+    aider: bool,
+) {
     let hint_str = match mode {
         AppMode::GitStatus => {
             "space select   s stage   z stash   Tab switch   c copy   m aider   ? help   q quit "
         }
-        AppMode::GitTree => {
-            "space select   d diff   c copy   m aider   ? help   q quit "
-        }
+        AppMode::GitTree => "space select   d diff   c copy   m aider   ? help   q quit ",
         AppMode::RgFocused | AppMode::RgNavigating => {
-            "' edit   y copy result   space select   c copy files   m aider   ? help   q quit "
+            "' edit   Tab switch panel   y copy result   space select   c copy files   m aider   ? help   q quit "
         }
         _ => "space select   c copy   m aider   ? help   q quit ",
     };
@@ -865,7 +998,9 @@ fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize
         if aider {
             spans.push(Span::styled(
                 " (aider patch)",
-                Style::default().fg(theme::MATCH).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(theme::MATCH)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
         let left = Line::from(spans);
@@ -877,22 +1012,18 @@ fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize
         )]);
         f.render_widget(Paragraph::new(error), chunks[0]);
     }
-
     let hint = Line::from(vec![Span::styled(
         hint_str,
         Style::default().fg(theme::MUTED),
     )]);
     f.render_widget(Paragraph::new(hint), chunks[1]);
 }
-
 fn render_help_overlay(f: &mut Frame, area: Rect) {
     let modal = centered_rect(60, 85, area);
     f.render_widget(Clear, modal);
-
     let block = panel("Keybindings", true);
     let inner = block.inner(modal);
     f.render_widget(block, modal);
-
     // Reserve the last inner row for the close hint.
     let content_area = Rect {
         height: inner.height.saturating_sub(1),
@@ -903,10 +1034,8 @@ fn render_help_overlay(f: &mut Frame, area: Rect) {
         height: inner.height.min(1),
         ..inner
     };
-
     let help_lines = build_help_lines();
     f.render_widget(Paragraph::new(help_lines), content_area);
-
     let close_hint = Line::from(vec![Span::styled(
         "? / Esc  close ",
         Style::default().fg(theme::MUTED),
@@ -914,7 +1043,6 @@ fn render_help_overlay(f: &mut Frame, area: Rect) {
     .right_aligned();
     f.render_widget(Paragraph::new(close_hint), hint_area);
 }
-
 fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
     let vertical = Layout::default()
         .direction(Direction::Vertical)
@@ -933,7 +1061,6 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
         ])
         .split(vertical[1])[1]
 }
-
 /// One keybinding per line, key padded to the width of the longest key.
 fn build_help_lines() -> Vec<Line<'static>> {
     const ALL: &[(&str, &str)] = &[
@@ -961,9 +1088,7 @@ fn build_help_lines() -> Vec<Line<'static>> {
         ("r", "Toggle relative path"),
         ("n", "Toggle no path headers"),
     ];
-
     let key_width = ALL.iter().map(|(k, _)| k.len()).max().unwrap_or(0);
-
     ALL.iter()
         .map(|(key, desc)| {
             Line::from(vec![
@@ -979,7 +1104,6 @@ fn build_help_lines() -> Vec<Line<'static>> {
         })
         .collect()
 }
-
 /// Collect all directory paths visible in the current tree view
 /// (top-level entries plus all recursively opened subdirectories).
 fn collect_visible_dirs(
@@ -1003,7 +1127,6 @@ fn collect_visible_dirs(
     }
     result
 }
-
 /// Build a `Line` from `text` where characters at `indices` use `match_style`
 /// and all others use `base_style`.
 fn highlight_matches(
@@ -1015,14 +1138,11 @@ fn highlight_matches(
     if indices.is_empty() {
         return Line::from(Span::styled(text.to_string(), base_style));
     }
-
     let matched: std::collections::HashSet<usize> = indices.iter().copied().collect();
     let chars: Vec<char> = text.chars().collect();
-
     let mut spans: Vec<Span<'static>> = Vec::new();
     let mut seg_start = 0;
     let mut seg_is_match = matched.contains(&0);
-
     for i in 1..=chars.len() {
         let cur_is_match = i < chars.len() && matched.contains(&i);
         if i == chars.len() || cur_is_match != seg_is_match {
@@ -1039,10 +1159,8 @@ fn highlight_matches(
             seg_is_match = cur_is_match;
         }
     }
-
     Line::from(spans)
 }
-
 /// Build styled TreeItems for a directory from the cache.
 /// Only recurses into directories that are in `open`.
 /// Closed directories with cached entries include flat stubs so the ▶ symbol shows.
@@ -1057,7 +1175,6 @@ fn build_styled_tree_items(
         Some(e) => e,
         None => return vec![],
     };
-
     entries
         .iter()
         .filter_map(|entry| {
@@ -1069,13 +1186,11 @@ fn build_styled_tree_items(
             } else {
                 raw_name
             };
-
             let is_selected = if is_dir {
                 fully_selected_dirs.contains(&path)
             } else {
                 selected.contains(&path)
             };
-
             let marker = if is_selected { "✓ " } else { "  " };
             let name_style = if is_dir {
                 Style::default().fg(theme::DIR)
@@ -1091,7 +1206,6 @@ fn build_styled_tree_items(
                 ),
                 Span::styled(display_name, name_style),
             ]);
-
             if is_dir {
                 let is_open = open.iter().any(|kp| kp.last() == Some(&path));
                 let children = if is_open {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -399,6 +399,7 @@ fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height:
     let staged: Vec<(usize, &GitStatusItem)> = app.git_status_items.iter().enumerate().filter(|(_, i)| i.section == GitStatusSection::Staged).collect();
     let unstaged: Vec<(usize, &GitStatusItem)> = app.git_status_items.iter().enumerate().filter(|(_, i)| i.section == GitStatusSection::Unstaged).collect();
     let untracked: Vec<(usize, &GitStatusItem)> = app.git_status_items.iter().enumerate().filter(|(_, i)| i.section == GitStatusSection::Untracked).collect();
+    let items_len = app.git_status_items.len();
 
     let header_style = Style::default().fg(theme::MUTED).add_modifier(Modifier::BOLD);
     let divider_style = Style::default().fg(theme::BORDER);
@@ -443,6 +444,24 @@ fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height:
         }
     }
 
+    push_header(&mut visual_items, "Stash", app.git_stash_items.len());
+    if app.git_stash_items.is_empty() {
+        visual_items.push((None, ListItem::new(Line::from(Span::styled("   (none)", Style::default().fg(theme::MUTED))))));
+    } else {
+        for (i, stash) in app.git_stash_items.iter().enumerate() {
+            let idx = items_len + i;
+            let is_cursor = idx == app.git_status_cursor;
+            let line = Line::from(vec![
+                Span::styled(
+                    format!("{} ", stash.stash_ref),
+                    Style::default().fg(theme::HASH).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(stash.message.clone(), Style::default().fg(theme::FG)),
+            ]);
+            visual_items.push((Some(idx), ListItem::new(line).style(if is_cursor { Style::default().bg(theme::CURSOR_BG) } else { Style::default() })));
+        }
+    }
+
     let selected_visual = visual_items.iter().position(|(idx, _)| *idx == Some(app.git_status_cursor)).unwrap_or(0);
 
     let scroll_offset = if selected_visual < app.git_status_scroll_offset {
@@ -465,11 +484,17 @@ fn render_git_status(f: &mut Frame, app: &mut AppState, area: Rect, list_height:
 
     // ── Right panel: diff ──
     app.sync_git_status_diff_scroll(list_height);
-    let diff_title = app
-        .git_status_items
-        .get(app.git_status_cursor)
-        .map(|i| i.path.clone())
-        .unwrap_or_else(|| "No changes".to_string());
+    let diff_title = if app.git_status_cursor < items_len {
+        app.git_status_items
+            .get(app.git_status_cursor)
+            .map(|i| i.path.clone())
+            .unwrap_or_else(|| "No changes".to_string())
+    } else {
+        app.git_stash_items
+            .get(app.git_status_cursor - items_len)
+            .map(|s| format!("{} {}", s.stash_ref, s.message))
+            .unwrap_or_else(|| "No stash".to_string())
+    };
     let diff_block = panel(&format!("Diff: {diff_title}"), app.git_status_diff_focused);
     let diff_inner_width = diff_block.inner(right_area).width;
     let cursor_line = if app.git_status_diff_focused {
@@ -509,7 +534,7 @@ fn build_git_status_line(app: &AppState, item: &GitStatusItem) -> Line<'static> 
 fn render_status_bar(f: &mut Frame, area: Rect, message: &str, file_count: usize, loc_count: u64, mode: AppMode, aider: bool) {
     let hint_str = match mode {
         AppMode::GitStatus => {
-            "space select   s stage   Tab switch   c copy   m aider   ? help   q quit "
+            "space select   s stage   z stash   Tab switch   c copy   m aider   ? help   q quit "
         }
         AppMode::GitTree => {
             "space select   d diff   c copy   m aider   ? help   q quit "
@@ -617,6 +642,8 @@ fn build_help_lines() -> Vec<Line<'static>> {
         ("2", "Git tree mode"),
         ("Tab", "Switch panel / exit git"),
         ("s", "Stage/Unstage (Git Status mode)"),
+        ("z", "Stash changes (Git Status mode)"),
+        ("Enter", "Pop stash (on stash item)"),
         ("d", "Toggle diff (Git mode)"),
         ("/ or Ctrl-f", "Search files"),
         ("?", "Toggle help"),

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -9,3 +9,4 @@ pub const SELECTED: Color = tailwind::EMERALD.c400;
 pub const CURSOR_BG: Color = tailwind::SLATE.c800;
 pub const MATCH: Color = tailwind::AMBER.c400;
 pub const HASH: Color = tailwind::YELLOW.c400;
+pub const REFS: Color = tailwind::GREEN.c400;


### PR DESCRIPTION
- Update git log format to include reflogs
- Add `refs` field to `GitCommit` struct
- Implement rendering for references with dedicated styling
- Add `REFS` color to theme
<img width="1316" height="871" alt="image" src="https://github.com/user-attachments/assets/87fbfdc1-856f-4473-8f66-80c0a84b3fbd" />
add --aider patch information can save the tokens and easy apply via patch merge tool
<img width="1401" height="944" alt="image" src="https://github.com/user-attachments/assets/68afe614-ec1a-4326-8a69-7a87214d2fec" />
